### PR TITLE
[8.x] Fix module panels in Filament

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
         {
           "type": "vcs",
           "url": "https://github.com/arthurpar06/laravel-theme"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/arthurpar06/filament-modules"
         }
       ],
     "require": {
@@ -92,7 +96,8 @@
         "socialiteproviders/vatsim": "^5.0",
         "socialiteproviders/ivao": "^4.0",
         "mailersend/laravel-driver": "^2.6",
-        "arxeiss/sansdaemon": "^1.3"
+        "arxeiss/sansdaemon": "^1.3",
+      "coolsam/modules": "3.x-dev"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05ba7bf3fdeaf2fa7194d10e022f0087",
+    "content-hash": "64888511c17139b2ddbeb32812d88c55",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -2010,6 +2010,97 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "coolsam/modules",
+            "version": "3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/arthurpar06/filament-modules.git",
+                "reference": "1eafd70dd13026b7f2aecce189040dd111393c85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/arthurpar06/filament-modules/zipball/1eafd70dd13026b7f2aecce189040dd111393c85",
+                "reference": "1eafd70dd13026b7f2aecce189040dd111393c85",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^3.0|^3.1|^3.2",
+                "illuminate/contracts": "^9.1|^10.0|^11.0",
+                "nwidart/laravel-modules": "^10.0|^11.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.14.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.0",
+                "nunomaduro/collision": "^7.9",
+                "orchestra/testbench": "^8.0",
+                "pestphp/pest": "^2.0",
+                "pestphp/pest-plugin-arch": "^2.0",
+                "pestphp/pest-plugin-laravel": "^2.0",
+                "spatie/laravel-ray": "^1.26"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Coolsam\\FilamentModules\\ModulesServiceProvider"
+                    ],
+                    "aliases": {
+                        "Modules": "Coolsam\\FilamentModules\\Facades\\Modules"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Coolsam\\FilamentModules\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Coolsam\\FilamentModules\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "post-autoload-dump": [
+                    "@php ./vendor/bin/testbench package:discover --ansi"
+                ],
+                "analyse": [
+                    "vendor/bin/phpstan analyse"
+                ],
+                "test": [
+                    "vendor/bin/pest"
+                ],
+                "test-coverage": [
+                    "vendor/bin/pest --coverage"
+                ],
+                "format": [
+                    "vendor/bin/pint"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Maosa",
+                    "email": "smaosa@savannabits.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Support for nwidart/laravel-modules in filamentphp",
+            "homepage": "https://github.com/coolsam/modules",
+            "keywords": [
+                "coolsam",
+                "laravel",
+                "modules"
+            ],
+            "support": {
+                "source": "https://github.com/arthurpar06/filament-modules/tree/3.x"
+            },
+            "time": "2025-01-16T20:06:20+00:00"
         },
         {
             "name": "danharrin/date-format-converter",
@@ -18599,6 +18690,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "coolsam/modules": 20,
         "igaster/laravel-theme": 20
     },
     "prefer-stable": true,
@@ -18613,6 +18705,6 @@
         "ext-intl": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
By default, modules are registered after Filament in Laravel, which means panels registered in modules are not recognized. I can't remember exactly what I changed, but with this customized forked package, modules are now registered before Filament.

This ensures that Filament module panels can be discovered