### PR TITLE
[8.x] Fix mariadb driver

### DIFF
--- a/app/Console/Commands/CreateDatabase.php
+++ b/app/Console/Commands/CreateDatabase.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Console\Services\Database;
 use App\Contracts\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Tivie\OS\Detector;
 
@@ -30,7 +31,7 @@ class CreateDatabase extends Command
      *
      * @return bool
      */
-    protected function create_mysql($dbkey)
+    protected function create_mysql_or_mariadb($dbkey)
     {
         $host = config($dbkey.'host');
         $port = config($dbkey.'port');
@@ -43,7 +44,7 @@ class CreateDatabase extends Command
         Log::info('Connection string: '.$dsn);
 
         try {
-            $conn = $dbSvc->createPDO($dsn, $user, $pass);
+            $conn = DB::connection(config('database.default'))->getPdo();
         } catch (\PDOException $e) {
             Log::error($e);
 
@@ -130,8 +131,8 @@ class CreateDatabase extends Command
         $conn = config('database.default');
         $dbkey = 'database.connections.'.$conn.'.';
 
-        if (config($dbkey.'driver') === 'mysql') {
-            $this->create_mysql($dbkey);
+        if (config($dbkey.'driver') === 'mysql' || config($dbkey.'driver') === 'mariadb') {
+            $this->create_mysql_or_mariadb($dbkey);
         } elseif (config($dbkey.'driver') === 'sqlite') {
             $this->create_sqlite($dbkey);
         } // TODO: Eventually

--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
             'unix_socket'    => env('DB_SOCKET', ''),
             'charset'        => env('DB_CHARSET', 'utf8mb4'),
             'collation'      => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
-            'prefix'         => '',
+            'prefix'         => env('DB_PREFIX', ''),
             'prefix_indexes' => true,
             'strict'         => true,
             'engine'         => null,


### PR DESCRIPTION
1. Add support for the mariadb driver in the `php artisan database:create` command.
2. Add support for db prefix in the mariadb driver