### PR TITLE
[8.x] fix: active state detection in ModuleLinksPlugin

### DIFF
--- a/resources/views/filament/plugins/module-links.blade.php
+++ b/resources/views/filament/plugins/module-links.blade.php
@@ -15,7 +15,7 @@
         }
 
         $panel_name = ucfirst(str_replace('::admin', '', $panel->getId()));
-        $active = str_contains(url()->current(), strtolower($panel_name));
+        $active = str_contains(request()->path(), strtolower($panel_name));
         $icon = 'heroicon-o-puzzle-piece';
       @endphp
       <x-filament-panels::topbar.item


### PR DESCRIPTION
Check if the module name is in the path instead of the full url