### PR TITLE
[7.x] Add missing `,` in email-plain.blade.php

### DIFF
--- a/resources/views/layouts/beta/notifications/email-plain.blade.php
+++ b/resources/views/layouts/beta/notifications/email-plain.blade.php
@@ -18,5 +18,5 @@ if(!empty($outroLines)) {
   echo implode("\n", $outroLines), "\n\n";
 }
 
-echo __('common.regards).', ', "\n";
+echo __('common.regards').', ', "\n";
 echo config('app.name'), "\n";

--- a/resources/views/layouts/seven/notifications/email-plain.blade.php
+++ b/resources/views/layouts/seven/notifications/email-plain.blade.php
@@ -18,5 +18,5 @@ if(!empty($outroLines)) {
   echo implode("\n", $outroLines), "\n\n";
 }
 
-echo __('common.regards).', ', "\n";
+echo __('common.regards').', ', "\n";
 echo config('app.name'), "\n";


### PR DESCRIPTION
Applies to both `7.x` and `8.x`