### PR TITLE
Update airport IDs/ICAOs to enforce 8-character format

### DIFF
--- a/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
+++ b/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('aircraft', function (Blueprint $table) {
+           $table->string('airport_id', 8)->change();
+           $table->string('hub_id', 8)->change();
+        });
+
+        Schema::table('airports', function (Blueprint $table) {
+            $table->string('id', 8)->change();
+            $table->string('icao', 8)->change();
+        });
+
+        Schema::table('flights', function (Blueprint $table) {
+            $table->string('dpt_airport_id', 8)->change();
+            $table->string('arr_airport_id', 8)->change();
+            $table->string('alt_airport_id', 8)->change();
+        });
+
+        Schema::table('pireps', function (Blueprint $table) {
+            $table->string('dpt_airport_id', 8)->change();
+            $table->string('arr_airport_id', 8)->change();
+            $table->string('alt_airport_id', 8)->change();
+        });
+
+        Schema::table('subfleets', function (Blueprint $table) {
+            $table->string('hub_id', 8)->change();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('home_airport_id', 8)->change();
+            $table->string('curr_airport_id', 8)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
+++ b/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
@@ -9,8 +9,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('aircraft', function (Blueprint $table) {
-           $table->string('airport_id', 8)->change();
-           $table->string('hub_id', 8)->change();
+           $table->string('airport_id', 8)->nullable()->change();
+           $table->string('hub_id', 8)->nullable()->change();
         });
 
         Schema::table('airports', function (Blueprint $table) {
@@ -21,22 +21,22 @@ return new class extends Migration
         Schema::table('flights', function (Blueprint $table) {
             $table->string('dpt_airport_id', 8)->change();
             $table->string('arr_airport_id', 8)->change();
-            $table->string('alt_airport_id', 8)->change();
+            $table->string('alt_airport_id', 8)->nullable()->change();
         });
 
         Schema::table('pireps', function (Blueprint $table) {
             $table->string('dpt_airport_id', 8)->change();
             $table->string('arr_airport_id', 8)->change();
-            $table->string('alt_airport_id', 8)->change();
+            $table->string('alt_airport_id', 8)->nullable()->change();
         });
 
         Schema::table('subfleets', function (Blueprint $table) {
-            $table->string('hub_id', 8)->change();
+            $table->string('hub_id', 8)->nullable()->change();
         });
 
         Schema::table('users', function (Blueprint $table) {
-            $table->string('home_airport_id', 8)->change();
-            $table->string('curr_airport_id', 8)->change();
+            $table->string('home_airport_id', 8)->nullable()->change();
+            $table->string('curr_airport_id', 8)->nullable()->change();
         });
     }
 


### PR DESCRIPTION
This pull request includes changes to update the size of ICAO fields in multiple database tables. The changes ensure that the relevant fields are now limited to a maximum of 8 characters.

Database schema updates:

* [`app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php`](diffhunk://#diff-262acb9e073c8ed0b86be75539278c12b8efdd19610c318aeb19839424cb7b09R1-R47): Updated the size of various ICAO-related fields in the `aircraft`, `airports`, `flights`, `pireps`, `subfleets`, and `users` tables to be 8 characters, with some fields also being made nullable.