### PR TITLE
Remove redundant `.htaccess` rule to allow apache access to `public/vendor`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ RedirectMatch 403 ^/node_modules/.*?$
 RedirectMatch 403 ^/resources/.*?$
 RedirectMatch 403 ^/storage/.*?$
 RedirectMatch 403 ^/tests/.*?$
-RedirectMatch 403 ^/vendor/.*?$
+#RedirectMatch 403 ^/vendor/.*?$
 RedirectMatch 403 ^/.bowerrc$
 RedirectMatch 403 ^/.env
 RedirectMatch 403 ^/artisan$


### PR DESCRIPTION
Okay, so basically, since we have a `vendor` folder at both the root and public levels, this rule in the `.htaccess` was preventing access to the `vendor` folder at the public level, which in turn blocked access to the LogViewer's assets.

This PR removes that rule, making it now possible for anyone using Apache to access the `public/vendor` folder. There's no risk of someone accessing the root `vendor` folder because there's a rule in the main `.htaccess` that redirects everything to `/public`.

A huge thanks to @FatihKoz for the help in testing this!

Closes #1992 

Should be merged in both `v7` and `v8`