### PR TITLE
Add Refresh Token System for OAuth Tokens

### DIFF
--- a/app/Cron/Nightly/RefreshOAuthTokens.php
+++ b/app/Cron/Nightly/RefreshOAuthTokens.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Cron\Nightly;
+
+use App\Contracts\Listener;
+use App\Events\CronNightly;
+use App\Services\OAuthService;
+
+class RefreshOAuthTokens extends Listener
+{
+    public function __construct(
+        private readonly OAuthService $oAuthSvc
+    ) {
+    }
+
+    public function handle(CronNightly $event): void
+    {
+        $this->oAuthSvc->refreshTokensBeforeTheyExpire();
+    }
+}

--- a/app/Cron/Nightly/RefreshOAuthTokens.php
+++ b/app/Cron/Nightly/RefreshOAuthTokens.php
@@ -10,8 +10,7 @@ class RefreshOAuthTokens extends Listener
 {
     public function __construct(
         private readonly OAuthService $oAuthSvc
-    ) {
-    }
+    ) {}
 
     public function handle(CronNightly $event): void
     {

--- a/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
+++ b/app/Database/migrations/2025_02_04_165053_update_icao_fields_size.php
@@ -4,13 +4,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class() extends Migration
 {
     public function up(): void
     {
         Schema::table('aircraft', function (Blueprint $table) {
-           $table->string('airport_id', 8)->nullable()->change();
-           $table->string('hub_id', 8)->nullable()->change();
+            $table->string('airport_id', 8)->nullable()->change();
+            $table->string('hub_id', 8)->nullable()->change();
         });
 
         Schema::table('airports', function (Blueprint $table) {

--- a/app/Database/migrations/2025_02_09_085529_update_user_oauth_tokens.php
+++ b/app/Database/migrations/2025_02_09_085529_update_user_oauth_tokens.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class() extends Migration
 {
     public function up(): void
     {

--- a/app/Database/migrations/2025_02_09_085529_update_user_oauth_tokens.php
+++ b/app/Database/migrations/2025_02_09_085529_update_user_oauth_tokens.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_oauth_tokens', function (Blueprint $table) {
+            $table->renameColumn('last_refreshed_at', 'expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_oauth_tokens', function (Blueprint $table) {
+            $table->renameColumn('last_refreshed_at', 'last_refreshed_at');
+        });
+    }
+};

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -95,7 +95,7 @@ class OAuthController extends Controller
             ], [
                 'token'             => $providerUser->token,
                 'refresh_token'     => $providerUser->refreshToken,
-                'last_refreshed_at' => now(),
+                'expires_at'        => now()->addSeconds($providerUser->expiresIn),
             ]);
 
             if ($provider === 'discord') {
@@ -149,7 +149,7 @@ class OAuthController extends Controller
             ], [
                 'token'             => $providerUser->token,
                 'refresh_token'     => $providerUser->refreshToken,
-                'last_refreshed_at' => now(),
+                'expires_at'        => now()->addSeconds($providerUser->expiresIn),
             ]);
 
             Auth::login($user, true);

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -93,9 +93,9 @@ class OAuthController extends Controller
                 'user_id'  => $user->id,
                 'provider' => $provider,
             ], [
-                'token'             => $providerUser->token,
-                'refresh_token'     => $providerUser->refreshToken,
-                'expires_at'        => now()->addSeconds($providerUser->expiresIn),
+                'token'         => $providerUser->token,
+                'refresh_token' => $providerUser->refreshToken,
+                'expires_at'    => now()->addSeconds($providerUser->expiresIn),
             ]);
 
             if ($provider === 'discord') {
@@ -147,9 +147,9 @@ class OAuthController extends Controller
                 'user_id'  => $user->id,
                 'provider' => $provider,
             ], [
-                'token'             => $providerUser->token,
-                'refresh_token'     => $providerUser->refreshToken,
-                'expires_at'        => now()->addSeconds($providerUser->expiresIn),
+                'token'         => $providerUser->token,
+                'refresh_token' => $providerUser->refreshToken,
+                'expires_at'    => now()->addSeconds($providerUser->expiresIn),
             ]);
 
             Auth::login($user, true);

--- a/app/Models/UserOAuthToken.php
+++ b/app/Models/UserOAuthToken.php
@@ -26,19 +26,19 @@ class UserOAuthToken extends Model
     ];
 
     protected $casts = [
-        'user_id'           => 'integer',
-        'provider'          => 'string',
-        'token'             => 'string',
-        'refresh_token'     => 'string',
-        'expires_at'        => 'datetime',
+        'user_id'       => 'integer',
+        'provider'      => 'string',
+        'token'         => 'string',
+        'refresh_token' => 'string',
+        'expires_at'    => 'datetime',
     ];
 
     public static $rules = [
-        'user_id'           => 'required|integer',
-        'provider'          => 'required|string',
-        'token'             => 'required|string',
-        'refresh_token'     => 'required|string',
-        'expires_at'        => 'nullable|datetime',
+        'user_id'       => 'required|integer',
+        'provider'      => 'required|string',
+        'token'         => 'required|string',
+        'refresh_token' => 'required|string',
+        'expires_at'    => 'nullable|datetime',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/UserOAuthToken.php
+++ b/app/Models/UserOAuthToken.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string         provider
  * @property string         token
  * @property string         refresh_token
- * @property \Carbon\Carbon last_refreshed_at
+ * @property \Carbon\Carbon expires_at
  */
 class UserOAuthToken extends Model
 {
@@ -22,7 +22,7 @@ class UserOAuthToken extends Model
         'provider',
         'token',
         'refresh_token',
-        'last_refreshed_at',
+        'expires_at',
     ];
 
     protected $casts = [
@@ -30,7 +30,7 @@ class UserOAuthToken extends Model
         'provider'          => 'string',
         'token'             => 'string',
         'refresh_token'     => 'string',
-        'last_refreshed_at' => 'datetime',
+        'expires_at'        => 'datetime',
     ];
 
     public static $rules = [
@@ -38,7 +38,7 @@ class UserOAuthToken extends Model
         'provider'          => 'required|string',
         'token'             => 'required|string',
         'refresh_token'     => 'required|string',
-        'last_refreshed_at' => 'nullable|datetime',
+        'expires_at'        => 'nullable|datetime',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/UserOAuthToken.php
+++ b/app/Models/UserOAuthToken.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -40,6 +41,13 @@ class UserOAuthToken extends Model
         'refresh_token' => 'required|string',
         'expires_at'    => 'nullable|datetime',
     ];
+
+    public function isExpired(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => now()->isAfter($this->expires_at),
+        );
+    }
 
     public function user(): BelongsTo
     {

--- a/app/Providers/CronServiceProvider.php
+++ b/app/Providers/CronServiceProvider.php
@@ -12,6 +12,7 @@ use App\Cron\Nightly\NewVersionCheck;
 use App\Cron\Nightly\PilotLeave;
 use App\Cron\Nightly\RecalculateBalances;
 use App\Cron\Nightly\RecalculateStats;
+use App\Cron\Nightly\RefreshOAuthTokens;
 use App\Cron\Nightly\SetActiveFlights;
 use App\Events\CronFifteenMinute;
 use App\Events\CronFiveMinute;
@@ -45,6 +46,7 @@ class CronServiceProvider extends ServiceProvider
             SetActiveFlights::class,
             RecalculateStats::class,
             NewVersionCheck::class,
+            RefreshOAuthTokens::class,
         ],
         CronWeekly::class => [
         ],

--- a/app/Providers/CronServiceProvider.php
+++ b/app/Providers/CronServiceProvider.php
@@ -50,7 +50,7 @@ class CronServiceProvider extends ServiceProvider
             RefreshOAuthTokens::class,
         ],
         CronWeekly::class => [
-            UpdateSimbriefData::class
+            UpdateSimbriefData::class,
         ],
         CronMonthly::class => [
             \App\Cron\Monthly\ApplyExpenses::class,

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -4,7 +4,6 @@ namespace App\Services;
 
 use App\Contracts\Service;
 use App\Models\UserOAuthToken;
-use Carbon\Carbon;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
@@ -29,13 +28,13 @@ class OAuthService extends Service
                 $updatedToken = Socialite::driver($token->provider)->refreshToken($token->refresh_token);
 
                 $token->update([
-                    'token' => $updatedToken->token,
+                    'token'         => $updatedToken->token,
                     'refresh_token' => $updatedToken->refreshToken,
-                    'expires_at' => now()->addSeconds($updatedToken->expiresIn),
+                    'expires_at'    => now()->addSeconds($updatedToken->expiresIn),
                 ]);
-                Log::debug('OAuth token refresh for user_id ' . $token->user_id . ' and provider ' . $token->provider);
+                Log::debug('OAuth token refresh for user_id '.$token->user_id.' and provider '.$token->provider);
             } catch (ClientException $e) {
-                Log::error("Error updating OAuth tokens: {$e->getMessage()}", ["exception" => $e, "token" => $token]);
+                Log::error("Error updating OAuth tokens: {$e->getMessage()}", ['exception' => $e, 'token' => $token]);
             }
         }
     }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Contracts\Service;
 use App\Models\UserOAuthToken;
 use GuzzleHttp\Exception\ClientException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -18,24 +19,47 @@ class OAuthService extends Service
         // we've likely already attempted to refresh it three times. Stopping retries avoids
         // an infinite loop every night.
 
+        // Note: we will apply a different policy for IVAO tokens, they'll be refreshed every week
+        // even if they expire every 30min.
+
         $start_date = now()->subHours(49);
         $end_date = now()->addHours(25);
 
-        $tokens = UserOAuthToken::whereBetween('expires_at', [$start_date, $end_date])->get();
+        $tokens = UserOAuthToken::where(function (Builder $query) use ($start_date, $end_date) {
+            return $query->whereNot('provider', 'ivao')
+                ->whereBetween('expires_at', [$start_date, $end_date]);
+        })
+            ->orWhere(function (Builder $query) {
+                return $query->where('provider', 'ivao')
+                    ->whereBetween('expires_at', [now()->subDays(8), now()->subDays(6)]);
+            })
+            ->get();
 
         foreach ($tokens as $token) {
-            try {
-                $updatedToken = Socialite::driver($token->provider)->refreshToken($token->refresh_token);
-
-                $token->update([
-                    'token'         => $updatedToken->token,
-                    'refresh_token' => $updatedToken->refreshToken,
-                    'expires_at'    => now()->addSeconds($updatedToken->expiresIn),
-                ]);
-                Log::debug('OAuth token refresh for user_id '.$token->user_id.' and provider '.$token->provider);
-            } catch (ClientException $e) {
-                Log::error("Error updating OAuth tokens: {$e->getMessage()}", ['exception' => $e, 'token' => $token]);
-            }
+            $this->refreshToken($token);
         }
+    }
+
+    public function refreshToken(UserOAuthToken $token): UserOAuthToken
+    {
+        try {
+            $updatedToken = Socialite::driver($token->provider)->refreshToken($token->refresh_token);
+
+            $token->update([
+                'token'         => $updatedToken->token,
+                'refresh_token' => $updatedToken->refreshToken,
+                'expires_at'    => now()->addSeconds($updatedToken->expiresIn),
+            ]);
+            Log::debug('OAuth token refresh for user_id '.$token->user_id.' and provider '.$token->provider);
+        } catch (ClientException $e) {
+            Log::error("Error updating OAuth tokens: {$e->getMessage()}", ['exception' => $e, 'token' => $token]);
+        }
+
+        return $token->refresh();
+    }
+
+    public function refreshTokenIfExpired(UserOAuthToken $token): UserOAuthToken
+    {
+        return ($token->isExpired) ? $this->refreshToken($token) : $token;
     }
 }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Service;
+use App\Models\UserOAuthToken;
+use Carbon\Carbon;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Facades\Log;
+use Laravel\Socialite\Facades\Socialite;
+
+class OAuthService extends Service
+{
+    public function refreshTokensBeforeTheyExpire(): void
+    {
+        // Refresh tokens that expired within the last 2 days or will expire in the next 24 hours.
+        // The future limit ensures we always have a valid token by refreshing it before expiration.
+        // The past limit prevents excessive retries—if a token expired more than 2 days ago,
+        // we've likely already attempted to refresh it three times. Stopping retries avoids
+        // an infinite loop every night.
+
+        $start_date = now()->subHours(49);
+        $end_date = now()->addHours(25);
+
+        $tokens = UserOAuthToken::whereBetween('expires_at', [$start_date, $end_date])->get();
+
+        foreach ($tokens as $token) {
+            try {
+                $updatedToken = Socialite::driver($token->provider)->refreshToken($token->refresh_token);
+
+                $token->update([
+                    'token' => $updatedToken->token,
+                    'refresh_token' => $updatedToken->refreshToken,
+                    'expires_at' => now()->addSeconds($updatedToken->expiresIn),
+                ]);
+                Log::debug('OAuth token refresh for user id ' . $token->user_id . ' and provider ' . $token->provider);
+            } catch (ClientException $e) {
+                Log::error("Error updating OAuth tokens: {$e->getMessage()}", ["exception" => $e, "token" => $token]);
+            }
+        }
+    }
+}

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -33,7 +33,7 @@ class OAuthService extends Service
                     'refresh_token' => $updatedToken->refreshToken,
                     'expires_at' => now()->addSeconds($updatedToken->expiresIn),
                 ]);
-                Log::debug('OAuth token refresh for user id ' . $token->user_id . ' and provider ' . $token->provider);
+                Log::debug('OAuth token refresh for user_id ' . $token->user_id . ' and provider ' . $token->provider);
             } catch (ClientException $e) {
                 Log::error("Error updating OAuth tokens: {$e->getMessage()}", ["exception" => $e, "token" => $token]);
             }

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -26,7 +26,7 @@ final class OAuthTest extends TestCase
         User::factory()->create();
 
         foreach ($this->drivers as $driver) {
-            Config::set('services.' . $driver . '.enabled', true);
+            Config::set('services.'.$driver.'.enabled', true);
         }
     }
 
@@ -37,9 +37,9 @@ final class OAuthTest extends TestCase
     {
         $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User')
             ->allows([
-                'getId' => 123456789,
-                'getName' => 'OAuth user',
-                'getEmail' => 'oauth.user@phpvms.net',
+                'getId'     => 123456789,
+                'getName'   => 'OAuth user',
+                'getEmail'  => 'oauth.user@phpvms.net',
                 'getAvatar' => 'https://en.gravatar.com/userimage/12856995/aa6c0527a723abfd5fb9e246f0ff8af4.png',
             ]);
 
@@ -50,7 +50,7 @@ final class OAuthTest extends TestCase
         return \Mockery::mock('Laravel\Socialite\Contracts\Provider')
             ->allows([
                 'refreshToken' => $abstractUser,
-                'user' => $abstractUser,
+                'user'         => $abstractUser,
             ]);
     }
 
@@ -60,7 +60,7 @@ final class OAuthTest extends TestCase
     public function test_link_account_from_profile(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
         Auth::login($user);
@@ -72,7 +72,7 @@ final class OAuthTest extends TestCase
                 ->assertRedirect(route('frontend.profile.index'));
 
             $user->refresh();
-            $this->assertEquals(123456789, $user->{$driver . '_id'});
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
 
             $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
 
@@ -89,7 +89,7 @@ final class OAuthTest extends TestCase
     public function test_link_account_from_login(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
 
@@ -100,7 +100,7 @@ final class OAuthTest extends TestCase
                 ->assertRedirect(route('frontend.dashboard.index'));
 
             $user->refresh();
-            $this->assertEquals(123456789, $user->{$driver . '_id'});
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
             $this->assertTrue($user->lastlogin_at->diffInSeconds(now()) <= 2);
 
             $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
@@ -120,19 +120,19 @@ final class OAuthTest extends TestCase
     public function test_login_with_linked_account(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
 
         foreach ($this->drivers as $driver) {
             $user->update([
-                $driver . '_id' => 123456789,
+                $driver.'_id' => 123456789,
             ]);
 
             UserOAuthToken::create([
-                'user_id' => $user->id,
-                'provider' => $driver,
-                'token' => 'token',
+                'user_id'       => $user->id,
+                'provider'      => $driver,
+                'token'         => 'token',
                 'refresh_token' => 'refresh_token',
             ]);
 
@@ -142,7 +142,7 @@ final class OAuthTest extends TestCase
                 ->assertRedirect(route('frontend.dashboard.index'));
 
             $user->refresh();
-            $this->assertEquals(123456789, $user->{$driver . '_id'});
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
             $this->assertTrue($user->lastlogin_at->diffInSeconds(now()) <= 2);
 
             $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
@@ -161,7 +161,7 @@ final class OAuthTest extends TestCase
     public function test_login_with_pending_account(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
             'state' => UserState::PENDING,
         ]);
@@ -195,13 +195,13 @@ final class OAuthTest extends TestCase
     public function test_unlink_account(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
 
         foreach ($this->drivers as $driver) {
             $user->update([
-                $driver . '_id' => 123456789,
+                $driver.'_id' => 123456789,
             ]);
 
             Auth::login($user);
@@ -210,7 +210,7 @@ final class OAuthTest extends TestCase
                 ->assertRedirect(route('frontend.profile.index'));
 
             $user->refresh();
-            $this->assertEmpty($user->{$driver . '_id'});
+            $this->assertEmpty($user->{$driver.'_id'});
         }
     }
 
@@ -252,24 +252,24 @@ final class OAuthTest extends TestCase
     public function test_refresh_expired_oauth_token(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
 
         foreach ($this->drivers as $driver) {
             $user->update([
-                $driver . '_id' => 123456789,
+                $driver.'_id' => 123456789,
             ]);
 
             UserOAuthToken::updateOrCreate(
                 [
-                    'user_id' => $user->id,
+                    'user_id'  => $user->id,
                     'provider' => $driver,
                 ],
                 [
-                    'token' => 'expired_token',
+                    'token'         => 'expired_token',
                     'refresh_token' => 'old_refresh_token',
-                    'expires_at' => now()->addHour(),
+                    'expires_at'    => now()->addHour(),
                 ]);
 
             Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -269,7 +269,7 @@ final class OAuthTest extends TestCase
                 [
                     'token'         => 'expired_token',
                     'refresh_token' => 'old_refresh_token',
-                    'expires_at'    => now()->addHour(),
+                    'expires_at'    => ($driver === 'ivao') ? now()->subWeek() : now()->addHour(),
                 ]);
 
             Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());


### PR DESCRIPTION

This pull request introduces several changes to enhance the OAuth token management system by adding a new service for refreshing tokens and updating related database schema and tests. The most important changes include creating a new `OAuthService` for token refresh, updating the database schema to rename a column, and modifying the `OAuthController` and `UserOAuthToken` model accordingly.

### New Service for OAuth Token Refresh:
* [`app/Services/OAuthService.php`](diffhunk://#diff-a5294ccbe4598e5602859d8e1af59d7e485b31c9f95f8c18a605fe538564ef13R1-R42): Introduced a new `OAuthService` class with a method to refresh OAuth tokens before they expire.

### Database Schema Update:
* [`app/Database/migrations/2025_02_09_085529_update_user_oauth_tokens.php`](diffhunk://#diff-e48ae0f1fd4632b8bc64df95db67e10291cdec9f5b23da05191df05d4d09b109R1-R22): Added a migration to rename the `last_refreshed_at` column to `expires_at` in the `user_oauth_tokens` table.

### Controller and Model Adjustments:
* [`app/Http/Controllers/Auth/OAuthController.php`](diffhunk://#diff-a4bdeb361e32cbaa45fa47630ae8615afb6f706d6497ceac36b0553c6b159e96L98-R98): Updated the `handleProviderCallback` method to use the new `expires_at` column. [[1]](diffhunk://#diff-a4bdeb361e32cbaa45fa47630ae8615afb6f706d6497ceac36b0553c6b159e96L98-R98) [[2]](diffhunk://#diff-a4bdeb361e32cbaa45fa47630ae8615afb6f706d6497ceac36b0553c6b159e96L152-R152)
* [`app/Models/UserOAuthToken.php`](diffhunk://#diff-231d0dff2f4c72c44d81140405e341a1306d36b80605a2f1a73b4dc79546f153L14-R14): Updated properties and casts to reflect the column name change from `last_refreshed_at` to `expires_at`. [[1]](diffhunk://#diff-231d0dff2f4c72c44d81140405e341a1306d36b80605a2f1a73b4dc79546f153L14-R14) [[2]](diffhunk://#diff-231d0dff2f4c72c44d81140405e341a1306d36b80605a2f1a73b4dc79546f153L25-R41)

### Cron Job and Service Provider:
* [`app/Cron/Nightly/RefreshOAuthTokens.php`](diffhunk://#diff-21e1ff9195abdcfcb6fbbe1b4910e1d0e7338e785fe7a033a32f2bdc77a18417R1-R20): Created a new cron job class to utilize the `OAuthService` for nightly token refresh.
* [`app/Providers/CronServiceProvider.php`](diffhunk://#diff-ee88acce63c780311e11811dc1c60c8c090e6d04879eedb12934a0ee614dff05R15): Registered the new `RefreshOAuthTokens` cron job. [[1]](diffhunk://#diff-ee88acce63c780311e11811dc1c60c8c090e6d04879eedb12934a0ee614dff05R15) [[2]](diffhunk://#diff-ee88acce63c780311e11811dc1c60c8c090e6d04879eedb12934a0ee614dff05R49)

### Test Updates:
* [`tests/OAuthTest.php`](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65R8): Added tests to cover the new token refresh functionality and updated existing tests to reflect the schema changes. [[1]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65R8) [[2]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65R48-R52) [[3]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65L79-R82) [[4]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65L108-R111) [[5]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65L134) [[6]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65L151) [[7]](diffhunk://#diff-adfca0942be5b3a13d572d23bcaf199a28968818dbdadf9d8c3f375a7ebe8a65R248-R287)

### Note:
While VATSIM and Discord (like most OAuth providers) issue access tokens valid for 7 days, it seems that IVAO's tokens are only valid for 30 minutes. I’ve reached out to them to confirm this behavior. If that's the case, we’ll need a specific refresh strategy for IVAO. This is why this is still in draft - I need to figure that out first.

Closes #1995 