### PR TITLE
Update default activity log retention time

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -10,7 +10,7 @@ return [
      * When the clean-command is executed, all recording activities older than
      * the number of days specified here will be deleted.
      */
-    'delete_records_older_than_days' => env('ACTIVITY_LOGGER_DELETE_RECORDS_OLDER_THAN_DAYS', 365),
+    'delete_records_older_than_days' => env('ACTIVITY_LOGGER_DELETE_RECORDS_OLDER_THAN_DAYS', 60),
 
     /*
      * If no log name is passed to the activity() helper


### PR DESCRIPTION
Should be applied to both `v7` and `v8`