### PR TITLE
[8.x] Add Import/Export CSV button back to Airports admin page

### DIFF
--- a/app/Filament/Resources/AirportResource/Pages/ListAirports.php
+++ b/app/Filament/Resources/AirportResource/Pages/ListAirports.php
@@ -2,9 +2,12 @@
 
 namespace App\Filament\Resources\AirportResource\Pages;
 
-use App\Filament\Resources\AirportResource;
 use Filament\Actions;
+use App\Filament\Resources\AirportResource;
 use Filament\Resources\Pages\ListRecords;
+use App\Filament\Actions\ExportAction;
+use App\Filament\Actions\ImportAction;
+use App\Models\Enums\ImportExportType;
 
 class ListAirports extends ListRecords
 {
@@ -13,6 +16,8 @@ class ListAirports extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ExportAction::make('export')->arguments(['resourceTitle' => 'airport', 'exportType' => ImportExportType::AIRPORT]),
+            ImportAction::make('import')->arguments(['resourceTitle' => 'airport', 'importType' => ImportExportType::AIRPORT]),
             Actions\CreateAction::make()->label('Add Airport')->icon('heroicon-o-plus-circle'),
         ];
     }

--- a/app/Filament/Resources/AirportResource/Pages/ListAirports.php
+++ b/app/Filament/Resources/AirportResource/Pages/ListAirports.php
@@ -16,8 +16,8 @@ class ListAirports extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            ExportAction::make('export')->arguments(['resourceTitle' => 'airport', 'exportType' => ImportExportType::AIRPORT]),
-            ImportAction::make('import')->arguments(['resourceTitle' => 'airport', 'importType' => ImportExportType::AIRPORT]),
+            ExportAction::make('export')->arguments(['resourceTitle' => 'airports', 'exportType' => ImportExportType::AIRPORT]),
+            ImportAction::make('import')->arguments(['resourceTitle' => 'airports', 'importType' => ImportExportType::AIRPORT]),
             Actions\CreateAction::make()->label('Add Airport')->icon('heroicon-o-plus-circle'),
         ];
     }


### PR DESCRIPTION
Simple PR adds back missing Import/Export CSV button to the Admin/Airports page.

This was tested with a CSV file from https://forum.phpvms.net/files/file/43-phpvms-7-airport-list/

Which uploaded into the mysql table.
