### PR TITLE
Optimize JournalRepository

### DIFF
--- a/app/Repositories/JournalRepository.php
+++ b/app/Repositories/JournalRepository.php
@@ -57,8 +57,8 @@ class JournalRepository extends Repository implements CacheableInterface
             'journal_id' => $journal->id,
         ];
 
-        $credits = Money::create($this->findWhere($where)->sum('credit') ?: 0);
-        $debits = Money::create($this->findWhere($where)->sum('debit') ?: 0);
+        $credits = Money::create($this->where($where)->sum('credit') ?: 0);
+        $debits = Money::create($this->where($where)->sum('debit') ?: 0);
         $balance = $credits->subtract($debits);
 
         $journal->balance = $balance->getAmount();


### PR DESCRIPTION
`findWhere` retrieves all entries matching the `where` statement, meaning we were fetching all those entries and then summing them manually, which was not optimized. With this PR, we now sum directly in SQL.  

This results in a huge improvement for large journals - `FinanceEventHandler` execution time dropped from over 13 seconds to less than 1 second on my prod

Changes in `app/Repositories/JournalRepository.php`:

* Updated method calls from `findWhere` to `where` in `recalculateBalance` function to improve query consistency.

Should be applied to both `v7` and `v8`