### PR TITLE
[8.x] Fix flight sorting

### DIFF
--- a/app/Filament/Resources/FlightResource.php
+++ b/app/Filament/Resources/FlightResource.php
@@ -182,7 +182,7 @@ class FlightResource extends Resource
                 TextColumn::make('ident')
                     ->label('Flight #')
                     ->searchable(['flight_number'])
-                    ->sortable(),
+                    ->sortable(['airline_id', 'flight_number']),
 
                 TextColumn::make('dpt_airport_id')
                     ->label('Dep')


### PR DESCRIPTION
This PR addresses an issue that occurs when trying to sort flights by their ident, because ident is an attribute and not a column in the table