### PR TITLE
[8.x] Add basic flight filters

### DIFF
--- a/app/Filament/Resources/FlightResource.php
+++ b/app/Filament/Resources/FlightResource.php
@@ -223,12 +223,14 @@ class FlightResource extends Resource
                     ->preload(),
 
                 Tables\Filters\SelectFilter::make('dpt_airport')
+                    ->label('Departure Airport')
                     ->relationship('dpt_airport', 'icao')
                     ->getOptionLabelFromRecordUsing(fn (Airport $record): string => $record->icao.' - '.$record->name)
                     ->searchable()
                     ->preload(),
 
                 Tables\Filters\SelectFilter::make('arr_airport')
+                    ->label('Arrival Airport')
                     ->relationship('arr_airport', 'icao')
                     ->getOptionLabelFromRecordUsing(fn (Airport $record): string => $record->icao.' - '.$record->name)
                     ->searchable()

--- a/app/Filament/Resources/FlightResource.php
+++ b/app/Filament/Resources/FlightResource.php
@@ -216,6 +216,23 @@ class FlightResource extends Resource
             ])
             ->filters([
                 Tables\Filters\TrashedFilter::make(),
+
+                Tables\Filters\SelectFilter::make('airline')
+                    ->relationship('airline', 'name')
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\SelectFilter::make('dpt_airport')
+                    ->relationship('dpt_airport', 'icao')
+                    ->getOptionLabelFromRecordUsing(fn (Airport $record): string => $record->icao.' - '.$record->name)
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\SelectFilter::make('arr_airport')
+                    ->relationship('arr_airport', 'icao')
+                    ->getOptionLabelFromRecordUsing(fn (Airport $record): string => $record->icao.' - '.$record->name)
+                    ->searchable()
+                    ->preload(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),


### PR DESCRIPTION
This PR adds three basic flight filters (airline, departure, and arrival airports) in order to make searching for flights in the admin interface a lot easier

![image](https://github.com/user-attachments/assets/0f6f649d-5f1a-4090-b12c-2c31f4e61699)
