### PR TITLE
[8.x] Add airline name in subfleet relationships

### DIFF
--- a/app/Filament/Resources/AircraftResource.php
+++ b/app/Filament/Resources/AircraftResource.php
@@ -39,7 +39,7 @@ class AircraftResource extends Resource
                         Forms\Components\Select::make('subfleet_id')
                             ->label('Subfleet')
                             ->relationship('subfleet')
-                            ->getOptionLabelFromRecordUsing(fn (Subfleet $record) => $record->airline->name .' - '.$record->name)
+                            ->getOptionLabelFromRecordUsing(fn (Subfleet $record) => $record->airline->name.' - '.$record->name)
                             ->preload()
                             ->searchable()
                             ->required()

--- a/app/Filament/Resources/AircraftResource.php
+++ b/app/Filament/Resources/AircraftResource.php
@@ -10,6 +10,7 @@ use App\Models\Airport;
 use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;
 use App\Models\File;
+use App\Models\Subfleet;
 use App\Services\FileService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -35,9 +36,11 @@ class AircraftResource extends Resource
                 Forms\Components\Section::make('subfleet_and_status')
                     ->heading('Subfleet And Status')
                     ->schema([
-                        Forms\Components\Select::make('subfleet')
+                        Forms\Components\Select::make('subfleet_id')
                             ->label('Subfleet')
-                            ->relationship('subfleet', 'name')
+                            ->relationship('subfleet')
+                            ->getOptionLabelFromRecordUsing(fn (Subfleet $record) => $record->airline->name .' - '.$record->name)
+                            ->preload()
                             ->searchable()
                             ->required()
                             ->native(false),

--- a/app/Filament/Resources/FlightResource/RelationManagers/SubfleetsRelationManager.php
+++ b/app/Filament/Resources/FlightResource/RelationManagers/SubfleetsRelationManager.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Resources\FlightResource\RelationManagers;
 
 use App\Models\Subfleet;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;

--- a/app/Filament/Resources/FlightResource/RelationManagers/SubfleetsRelationManager.php
+++ b/app/Filament/Resources/FlightResource/RelationManagers/SubfleetsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\FlightResource\RelationManagers;
 
+use App\Models\Subfleet;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -33,9 +34,11 @@ class SubfleetsRelationManager extends RelationManager
                 //
             ])
             ->headerActions([
-                Tables\Actions\AttachAction::make()->icon('heroicon-o-plus-circle')->recordSelect(function (Select $select) {
-                    return $select->multiple();
-                }),
+                Tables\Actions\AttachAction::make()
+                    ->icon('heroicon-o-plus-circle')
+                    ->multiple()
+                    ->preloadRecordSelect()
+                    ->recordTitle(fn (Subfleet $record): string => $record->airline->name.' - '.$record->name),
             ])
             ->actions([
                 Tables\Actions\DetachAction::make(),

--- a/app/Filament/Resources/RankResource/RelationManagers/SubfleetsRelationManager.php
+++ b/app/Filament/Resources/RankResource/RelationManagers/SubfleetsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\RankResource\RelationManagers;
 
+use App\Models\Subfleet;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
@@ -33,7 +34,11 @@ class SubfleetsRelationManager extends RelationManager
                 //
             ])
             ->headerActions([
-                Tables\Actions\AttachAction::make()->label('Add')->icon('heroicon-o-plus-circle'),
+                Tables\Actions\AttachAction::make()
+                    ->icon('heroicon-o-plus-circle')
+                    ->multiple()
+                    ->preloadRecordSelect()
+                    ->recordTitle(fn (Subfleet $record): string => $record->airline->name.' - '.$record->name),
             ])
             ->actions([
                 Tables\Actions\DetachAction::make(),

--- a/app/Filament/Resources/TypeRatingResource/RelationManagers/SubfleetsRelationManager.php
+++ b/app/Filament/Resources/TypeRatingResource/RelationManagers/SubfleetsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\TypeRatingResource\RelationManagers;
 
+use App\Models\Subfleet;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
@@ -31,7 +32,11 @@ class SubfleetsRelationManager extends RelationManager
                 //
             ])
             ->headerActions([
-                Tables\Actions\AttachAction::make(),
+                Tables\Actions\AttachAction::make()
+                    ->icon('heroicon-o-plus-circle')
+                    ->multiple()
+                    ->preloadRecordSelect()
+                    ->recordTitle(fn (Subfleet $record): string => $record->airline->name.' - '.$record->name),
             ])
             ->actions([
                 Tables\Actions\DetachAction::make(),


### PR DESCRIPTION
This PR adds the subfleet's airline name in the subfleet select text so that people can better understand which subfleet they are adding. For instance, if you have two subfleets named "A320" in two different airlines, you'll now know which one you're adding

![image](https://github.com/user-attachments/assets/5579fa7a-a365-44ba-9971-c6758a4e896d)
