### PR TITLE
[8.x] Enable image upload functionality for awards

### DIFF
--- a/app/Filament/Resources/AwardResource.php
+++ b/app/Filament/Resources/AwardResource.php
@@ -51,7 +51,7 @@ class AwardResource extends Resource
                         Forms\Components\TextInput::make('image_url')
                             ->label('Image URL')
                             ->url()
-                            ->requiredWithout('file'),
+                            ->requiredWithout('image_file'),
 
                         Forms\Components\FileUpload::make('image_file')
                             ->label('Image')

--- a/app/Filament/Resources/AwardResource.php
+++ b/app/Filament/Resources/AwardResource.php
@@ -46,10 +46,20 @@ class AwardResource extends Resource
                             ->required()
                             ->string(),
 
-                        Forms\Components\TextInput::make('image_url')
-                            ->string(),
-
                         Forms\Components\RichEditor::make('description'),
+
+                        Forms\Components\TextInput::make('image_url')
+                            ->label('Image URL')
+                            ->url()
+                            ->requiredWithout('file'),
+
+                        Forms\Components\FileUpload::make('image_file')
+                            ->label('Image')
+                            ->image()
+                            ->imageEditor()
+                            ->disk(config('filesystems.public_files'))
+                            ->directory('awards')
+                            ->requiredWithout('image_url'),
 
                         Forms\Components\Grid::make('')
                             ->schema([

--- a/app/Filament/Resources/AwardResource.php
+++ b/app/Filament/Resources/AwardResource.php
@@ -50,16 +50,14 @@ class AwardResource extends Resource
 
                         Forms\Components\TextInput::make('image_url')
                             ->label('Image URL')
-                            ->url()
-                            ->requiredWithout('image_file'),
+                            ->url(),
 
                         Forms\Components\FileUpload::make('image_file')
                             ->label('Image')
                             ->image()
                             ->imageEditor()
                             ->disk(config('filesystems.public_files'))
-                            ->directory('awards')
-                            ->requiredWithout('image_url'),
+                            ->directory('awards'),
 
                         Forms\Components\Grid::make('')
                             ->schema([

--- a/app/Filament/Resources/AwardResource/Pages/CreateAward.php
+++ b/app/Filament/Resources/AwardResource/Pages/CreateAward.php
@@ -8,4 +8,13 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateAward extends CreateRecord
 {
     protected static string $resource = AwardResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (!empty($data['image_file'])) {
+            $data['image_url'] = $data['image_file'];
+        }
+
+        return $data;
+    }
 }

--- a/app/Filament/Resources/AwardResource/Pages/EditAward.php
+++ b/app/Filament/Resources/AwardResource/Pages/EditAward.php
@@ -18,4 +18,23 @@ class EditAward extends EditRecord
             Actions\RestoreAction::make(),
         ];
     }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        if (array_key_exists('image_url', $data) && str_starts_with($data['image_url'], 'awards/')) {
+            $data['image_file'] = $data['image_url'];
+            unset($data['image_url']);
+        }
+
+        return $data;
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if (!empty($data['image_file'])) {
+            $data['image_url'] = $data['image_file'];
+        }
+
+        return $data;
+    }
 }

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
 use Kyslik\ColumnSortable\Sortable;
 
 /**
@@ -70,6 +72,23 @@ class Award extends Model
         } catch (\Exception $e) {
             return;
         }
+    }
+
+    public function imageUrl(): Attribute
+    {
+        return Attribute::make(
+            get: function ($_, $attrs) {
+                if (array_key_exists('image_url', $attrs)) {
+                    if (str_starts_with($attrs['image_url'], 'awards/')) {
+                        return Storage::disk('public')->url($attrs['image_url']);
+                    }
+
+                    return $attrs['image_url'];
+                }
+
+                return null;
+            }
+        );
     }
 
     public function users(): BelongsToMany

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -80,7 +80,7 @@ class Award extends Model
             get: function ($_, $attrs) {
                 if (array_key_exists('image_url', $attrs)) {
                     if (str_starts_with($attrs['image_url'], 'awards/')) {
-                        return Storage::disk('public')->url($attrs['image_url']);
+                        return Storage::disk(config('filesystems.public_files'))->url($attrs['image_url']);
                     }
 
                     return $attrs['image_url'];

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -74,7 +74,7 @@ class Award extends Model
         }
     }
 
-    public function imageUrl(): Attribute
+    public function image(): Attribute
     {
         return Attribute::make(
             get: function ($_, $attrs) {

--- a/public/uploads/.gitignore
+++ b/public/uploads/.gitignore
@@ -2,3 +2,4 @@
 !files/
 !avatars/
 !.gitignore
+!awards/

--- a/public/uploads/awards/.gitignore
+++ b/public/uploads/awards/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR enables the direct upload of images for awards, eliminating the previous requirement to only use urls. Now, you can either upload an image or enter a url. Additionally, the image upload feature includes an image editor for enhanced functionality.

The award model now includes an `image` attribute, allowing it to store either the URL of an uploaded file or a direct URL. This change is significant for theme developers transitioning from v7 to v8, as they will need to use `$award->image` in v8 to access uploaded images.

If desired, I can add an `image` attribute to v7 to maintain consistency across versions. This would enable the same theme or module to work seamlessly in both v7 and v8 using `$award->image`.

![image](https://github.com/user-attachments/assets/a22f0a31-041c-441b-85c2-2df8cdd327ba)
![image](https://github.com/user-attachments/assets/fb0deddb-0c48-467a-9fa9-7c0cca3d8d6d)
