### PR TITLE
[7.x] Fix integer overflow in journal balances 

### DIFF
--- a/app/Models/Casts/MoneyCast.php
+++ b/app/Models/Casts/MoneyCast.php
@@ -36,6 +36,6 @@ class MoneyCast implements CastsAttributes
             ? $value
             : new Money($value);
 
-        return $value ? (int) $value->getAmount() : null;
+        return $value ? $value->getAmount() : null;
     }
 }


### PR DESCRIPTION
## The Problem
In one of my installs I've noticed the balance column in the journals table was not getting set correctly by nightly cron task. It had minus values while sums should've been positive. (This effects @FatihKoz's Disposable Module's Manual Payment Feature)

**For example 6559487992 was turning into -2030446600**. Which immediately reminded me an integer overflow but I had to hunt for its source for a while. 

- This problem did not occur in every system. It was fine in Sail and in multiple VPS setups but not in shared hosting.
- It happened in 64 bit PHP and PHP_INT_MAX reporting _9223372036854775807_ 64 bit precision.
- Happened even when column was set as TEXT.

## The Find
I was able to hunt it to this integer cast done to result of `Money()->getAmount()`. My guess is, in some systems this returns a float instead of integer. Causing a weird overflow on recast. What is worse, it happens completely out of sight, even `DB::listen` was showing the correct value but negative value would appear in the database almost by magic.

## The Solution
To remove `(int)` cast from `MoneyCast`. `Money()->getAmount()` is **supposed to return a float or int anyway** and database should do its own if further casting is needed.