### PR TITLE
fix module links

### DIFF
--- a/app/Filament/Plugins/ModuleLinksPlugin.php
+++ b/app/Filament/Plugins/ModuleLinksPlugin.php
@@ -57,7 +57,7 @@ class ModuleLinksPlugin implements Plugin
             $panel_name = ucfirst(str_replace('::admin', '', $panel->getId()));
             $items[] = NavigationItem::make($panel_name)
                 ->icon('heroicon-o-puzzle-piece')
-                ->url($panel->getPath());
+                ->url(url($panel->getPath()));
         }
 
         $old_links = array_filter(app(ModuleService::class)->getAdminLinks(), static fn (array $link): bool => !str_contains($link['title'], 'Sample'));


### PR DESCRIPTION
This pull request updates the URL generation in the `getGroup` function of the `ModuleLinksPlugin` class to ensure proper URL formatting.

### Changes to URL generation:
* [`app/Filament/Plugins/ModuleLinksPlugin.php`](diffhunk://#diff-855e07a7e0ce8b2757caf1ff58788f65f32dc8bdebe111ca95dd525f09eccb51L60-R60): Updated the `url` method in the `getGroup` function to wrap `$panel->getPath()` with the global `url()` helper, ensuring the generated URLs are absolute.