### PR TITLE
Flight Duplicate Check for only Core Flights

### DIFF
--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -214,6 +214,7 @@ class FlightService extends Service
             ['id', '<>', $flight->id],
             'airline_id'    => $flight->airline_id,
             'flight_number' => $flight->flight_number,
+            'owner_type'    => null,
         ];
 
         $found_flights = $this->flightRepo->findWhere($where);


### PR DESCRIPTION
closes #2054 

This addresses an issue where we need to disable the duplicate check for module-owned flights.

I have not fully tested this out to verify it's working. Hold off on merging until it's tested, or if there's a automated test that does test this code properly.

This will optionally need to be ported to v7.