### PR TITLE
fix: flights.scripts breaking view chain

### DIFF
--- a/resources/views/layouts/seven/flights/scripts.blade.php
+++ b/resources/views/layouts/seven/flights/scripts.blade.php
@@ -1,4 +1,5 @@
 @section('scripts')
+    @parent
     @if (setting('bids.block_aircraft', false))
         <script>
             document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
We've noticed when using Disposable Special addon's Tour map wouldn't work. 

When I investigated the problem I tracked it to following.
- `ExpandTourMap()` javascript function in [DisposableSpecial/blob/main/Resources/views/tours/show.blade.php](https://github.com/FatihKoz/DisposableSpecial/blob/main/Resources/views/tours/show.blade.php) would not render on raw html response of laravel. Hence `@yield('scripts')` on app view was failing somewhere.
- Removing `@include('DSpecial::tours.legs_table')` would fix the issue.
- [DisposableSpecial/blob/main/Resources/views/tours/legs_table.blade.php](https://github.com/FatihKoz/DisposableSpecial/blob/main/Resources/views/tours/legs_table.blade.php) includes [resources/views/layouts/seven/flights/scripts.blade.php](resources/views/layouts/seven/flights/scripts.blade.php). Which also has a `@section('scripts')` which takes presedence and overwrites the `scripts` from its parent.

Adding a simple `@parent` seems to have solved the issue. All injections to `@yield('scripts')` on app.blade.php are working fine from what I can observe. 

I'll be impletementing this as a template override in one of my sites. If it will cause any unforseen effects I'll be in touch. But it seems OK so far.