### PR TITLE
feat: reintroduce ide-helper

### DIFF
--- a/app/Models/Acars.php
+++ b/app/Models/Acars.php
@@ -11,19 +11,65 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property string id
- * @property string pirep_id
- * @property int    type
- * @property string name
- * @property float  lat
- * @property float  lon
- * @property float  altitude_agl
- * @property float  altitude_msl
- * @property int    gs
- * @property int    ias
- * @property int    heading
- * @property int    order
- * @property int    nav_type
+ * @property string                          $id
+ * @property string                          $pirep_id
+ * @property int                             $type
+ * @property int|null                        $nav_type
+ * @property int                             $order
+ * @property string|null                     $name
+ * @property string                          $status
+ * @property string|null                     $log
+ * @property float|null                      $lat
+ * @property float|null                      $lon
+ * @property mixed|null                      $distance
+ * @property int|null                        $heading
+ * @property float|null                      $altitude_agl
+ * @property float|null                      $altitude_msl
+ * @property float|null                      $vs
+ * @property int|null                        $gs
+ * @property int|null                        $ias
+ * @property int|null                        $transponder
+ * @property string|null                     $autopilot
+ * @property mixed|null                      $fuel
+ * @property float|null                      $fuel_flow
+ * @property string|null                     $sim_time
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null                     $source
+ * @property mixed|null                      $altitude
+ * @property-read \App\Models\Pirep|null $pirep
+ *
+ * @method static \Database\Factories\AcarsFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereAltitudeAgl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereAltitudeMsl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereAutopilot($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereDistance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereFuel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereFuelFlow($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereGs($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereHeading($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereIas($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereLat($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereLog($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereLon($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereNavType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars wherePirepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereSimTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereSource($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereStatus($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereTransponder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Acars whereVs($value)
+ *
+ * @mixin \Eloquent
  */
 class Acars extends Model
 {

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -22,33 +22,86 @@ use Znck\Eloquent\Relations\BelongsToThrough as ZnckBelongsToThrough;
 use Znck\Eloquent\Traits\BelongsToThrough;
 
 /**
- * @property int      id
- * @property mixed    subfleet_id
- * @property string   airport_id   The apt where the aircraft is
- * @property string   hub_id       The apt where the aircraft is based
- * @property string   ident
- * @property string   name
- * @property string   icao
- * @property string   registration
- * @property string   fin
- * @property int      flight_time
- * @property Mass     dow
- * @property Mass     mlw
- * @property Mass     mtow
- * @property Mass     zfw
- * @property string   hex_code
- * @property string   selcal
- * @property Airport  airport
- * @property Airport  hub
- * @property Airport  home
- * @property Airline  airline
- * @property Subfleet subfleet
- * @property int      status
- * @property int      state
- * @property string   simbrief_type
- * @property Carbon   landing_time
- * @property Fuel     fuel_onboard
- * @property Bid      bid
+ * @property int                             $id
+ * @property int                             $subfleet_id
+ * @property string|null                     $icao
+ * @property string|null                     $iata
+ * @property string|null                     $airport_id
+ * @property string|null                     $hub_id
+ * @property string|null                     $landing_time
+ * @property string                          $name
+ * @property string|null                     $registration
+ * @property string|null                     $fin
+ * @property string|null                     $hex_code
+ * @property string|null                     $selcal
+ * @property mixed|null                      $dow
+ * @property mixed|null                      $mtow
+ * @property mixed|null                      $mlw
+ * @property mixed|null                      $zfw
+ * @property string|null                     $simbrief_type
+ * @property mixed|null                      $fuel_onboard
+ * @property float|null                      $flight_time
+ * @property string                          $status
+ * @property int                             $state
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read mixed $active
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \App\Models\Airport|null $airport
+ * @property-read \App\Models\Bid|null $bid
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Expense> $expenses
+ * @property-read int|null $expenses_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\File> $files
+ * @property-read int|null $files_count
+ * @property-read \App\Models\Airport|null $home
+ * @property-read \App\Models\Airport|null $hub
+ * @property-read mixed $ident
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Pirep> $pireps
+ * @property-read int|null $pireps_count
+ * @property-read \App\Models\SimBriefAircraft|null $sbaircraft
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SimBriefAirframe> $sbairframes
+ * @property-read int|null $sbairframes_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SimBrief> $simbriefs
+ * @property-read int|null $simbriefs_count
+ * @property-read \App\Models\Subfleet|null $subfleet
+ * @property-read \App\Models\Airline|null $airline
+ *
+ * @method static \Database\Factories\AircraftFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereDow($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereFin($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereFlightTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereFuelOnboard($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereHexCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereHubId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereIata($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereIcao($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereLandingTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereMlw($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereMtow($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereRegistration($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereSelcal($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereSimbriefType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereState($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereStatus($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereSubfleetId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft whereZfw($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Aircraft withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Aircraft extends Model
 {

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -17,15 +17,59 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property mixed   id
- * @property string  code
- * @property string  icao
- * @property string  iata
- * @property string  name
- * @property string  callsign
- * @property string  logo
- * @property string  country
- * @property Journal journal
+ * @property int                             $id
+ * @property string                          $icao
+ * @property string|null                     $iata
+ * @property string                          $name
+ * @property string|null                     $callsign
+ * @property string|null                     $country
+ * @property string|null                     $logo
+ * @property bool                            $active
+ * @property int|null                        $total_flights
+ * @property int|null                        $total_time
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Aircraft> $aircraft
+ * @property-read int|null $aircraft_count
+ * @property-read mixed $code
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\File> $files
+ * @property-read int|null $files_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Flight> $flights
+ * @property-read int|null $flights_count
+ * @property-read \App\Models\Journal|null $journal
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Pirep> $pireps
+ * @property-read int|null $pireps_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Subfleet> $subfleets
+ * @property-read int|null $subfleets_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Database\Factories\AirlineFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereCallsign($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereCountry($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereIata($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereIcao($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereLogo($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereTotalFlights($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereTotalTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airline withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Airline extends Model
 {

--- a/app/Models/Airport.php
+++ b/app/Models/Airport.php
@@ -16,25 +16,72 @@ use Spatie\Activitylog\Traits\LogsActivity;
 /**
  * Class Airport
  *
- * @property string id
- * @property string iata
- * @property string icao
- * @property string name
- * @property string full_name
- * @property string description
- * @property string location
- * @property string region
- * @property string country
- * @property string timezone
- * @property string notes
- * @property float  ground_handling_cost
- * @property float  fuel_100ll_cost
- * @property float  fuel_jeta_cost
- * @property float  fuel_mogas_cost
- * @property float  lat
- * @property float  lon
- * @property int    elevation
- * @property bool   hub
+ * @property string                          $id
+ * @property string|null                     $iata
+ * @property string                          $icao
+ * @property string                          $name
+ * @property string|null                     $location
+ * @property string|null                     $region
+ * @property string|null                     $country
+ * @property string|null                     $timezone
+ * @property bool                            $hub
+ * @property string|null                     $notes
+ * @property float|null                      $lat
+ * @property float|null                      $lon
+ * @property int|null                        $elevation
+ * @property float|null                      $ground_handling_cost
+ * @property float|null                      $fuel_100ll_cost
+ * @property float|null                      $fuel_jeta_cost
+ * @property float|null                      $fuel_mogas_cost
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Aircraft> $aircraft
+ * @property-read int|null $aircraft_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Flight> $arrivals
+ * @property-read int|null $arrivals_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Flight> $departures
+ * @property-read int|null $departures_count
+ * @property-read mixed $description
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Expense> $expenses
+ * @property-read int|null $expenses_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\File> $files
+ * @property-read int|null $files_count
+ * @property-read mixed $full_name
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $pilots
+ * @property-read int|null $pilots_count
+ * @property mixed $tz
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Database\Factories\AirportFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereCountry($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereElevation($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereFuel100llCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereFuelJetaCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereFuelMogasCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereGroundHandlingCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereHub($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereIata($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereIcao($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereLat($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereLocation($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereLon($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereNotes($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereRegion($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport whereTimezone($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Airport withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Airport extends Model
 {

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -14,13 +14,40 @@ use Kyslik\ColumnSortable\Sortable;
 /**
  * The Award model
  *
- * @property mixed      id
- * @property string     name
- * @property string     description
- * @property string     title
- * @property string     image
- * @property mixed      ref_model
- * @property mixed|null ref_model_params
+ * @property int                             $id
+ * @property string                          $name
+ * @property string|null                     $description
+ * @property string|null                     $image_url
+ * @property string|null                     $ref_model
+ * @property string|null                     $ref_model_params
+ * @property int|null                        $active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read mixed $image
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Database\Factories\AwardFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereImageUrl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereRefModel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereRefModelParams($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Award withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Award extends Model
 {

--- a/app/Models/Bid.php
+++ b/app/Models/Bid.php
@@ -3,19 +3,30 @@
 namespace App\Models;
 
 use App\Contracts\Model;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property int      user_id
- * @property string   flight_id
- * @property int      aircraft_id
- * @property Carbon   created_at
- * @property Carbon   updated_at
- * @property Aircraft aircraft
- * @property Flight   flight
- * @property User     user
- * @property mixed    flights
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property string                          $flight_id
+ * @property int|null                        $aircraft_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Aircraft|null $aircraft
+ * @property-read \App\Models\Flight|null $flight
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereAircraftId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereFlightId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Bid whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class Bid extends Model
 {

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -4,6 +4,32 @@ namespace App\Models;
 
 use App\Contracts\Model;
 
+/**
+ * @property int                             $id
+ * @property int                             $type
+ * @property string                          $name
+ * @property string|null                     $description
+ * @property \Illuminate\Support\Carbon      $start_date
+ * @property \Illuminate\Support\Carbon      $end_date
+ * @property int|null                        $active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereEndDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereStartDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Event whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
 class Event extends Model
 {
     public $table = 'events';

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -11,17 +11,40 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
- * @property int     airline_id
- * @property float   amount
- * @property string  name
- * @property string  type
- * @property string  flight_type
- * @property string  ref_model
- * @property string  ref_model_id
- * @property bool    charge_to_user
- * @property Airline $airline
+ * @property int                                                $id
+ * @property int|null                                           $airline_id
+ * @property string                                             $name
+ * @property int                                                $amount
+ * @property string                                             $type
+ * @property mixed|null                                         $flight_type
+ * @property int|null                                           $charge_to_user
+ * @property int|null                                           $multiplier
+ * @property int|null                                           $active
+ * @property \Illuminate\Database\Eloquent\Model|\Eloquent|null $ref_model
+ * @property string|null                                        $ref_model_id
+ * @property \Illuminate\Support\Carbon|null                    $created_at
+ * @property \Illuminate\Support\Carbon|null                    $updated_at
+ * @property-read \App\Models\Airline|null $airline
  *
- * @mixin Builder
+ * @method static \Database\Factories\ExpenseFactory factory($count = null, $state = [])
+ * @method static Builder<static>|Expense            newModelQuery()
+ * @method static Builder<static>|Expense            newQuery()
+ * @method static Builder<static>|Expense            query()
+ * @method static Builder<static>|Expense            whereActive($value)
+ * @method static Builder<static>|Expense            whereAirlineId($value)
+ * @method static Builder<static>|Expense            whereAmount($value)
+ * @method static Builder<static>|Expense            whereChargeToUser($value)
+ * @method static Builder<static>|Expense            whereCreatedAt($value)
+ * @method static Builder<static>|Expense            whereFlightType($value)
+ * @method static Builder<static>|Expense            whereId($value)
+ * @method static Builder<static>|Expense            whereMultiplier($value)
+ * @method static Builder<static>|Expense            whereName($value)
+ * @method static Builder<static>|Expense            whereRefModel($value)
+ * @method static Builder<static>|Expense            whereRefModelId($value)
+ * @method static Builder<static>|Expense            whereType($value)
+ * @method static Builder<static>|Expense            whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Expense extends Model
 {

--- a/app/Models/Fare.php
+++ b/app/Models/Fare.php
@@ -10,15 +10,46 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string  name
- * @property float   cost
- * @property float   price
- * @property int     code
- * @property int     capacity
- * @property int     count Only when merged with pivot
- * @property int     type
- * @property string  notes
- * @property bool    active
+ * @property int                             $id
+ * @property string                          $code
+ * @property string                          $name
+ * @property float|null                      $price
+ * @property float|null                      $cost
+ * @property int|null                        $capacity
+ * @property int|null                        $type
+ * @property string|null                     $notes
+ * @property bool                            $active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Flight> $flights
+ * @property-read int|null $flights_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Subfleet> $subfleets
+ * @property-read int|null $subfleets_count
+ *
+ * @method static \Database\Factories\FareFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereCapacity($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereNotes($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare wherePrice($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Fare withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Fare extends Model
 {

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -10,14 +10,38 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 /**
- * @property string $name
- * @property string $description
- * @property string $disk
- * @property string $path
- * @property bool   $public
- * @property int    $download_count
- * @property string $url
- * @property string $filename
+ * @property string                          $id
+ * @property string                          $name
+ * @property string|null                     $description
+ * @property string|null                     $disk
+ * @property string|null                     $path
+ * @property bool                            $public
+ * @property int                             $download_count
+ * @property string|null                     $ref_model
+ * @property string|null                     $ref_model_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read mixed $extension
+ * @property-read mixed $filename
+ * @property-read bool $is_external_file
+ * @property-read mixed $url
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereDisk($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereDownloadCount($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File wherePath($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File wherePublic($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereRefModel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereRefModelId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|File whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class File extends Model
 {

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -6,8 +6,6 @@ use App\Contracts\Model;
 use App\Models\Casts\DistanceCast;
 use App\Models\Enums\Days;
 use App\Models\Traits\HashIdTrait;
-use App\Support\Units\Distance;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,49 +14,108 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Collection;
 use Kyslik\ColumnSortable\Sortable;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string     id
- * @property mixed      ident
- * @property mixed      atc
- * @property Airline    airline
- * @property int        airline_id
- * @property mixed      flight_number
- * @property mixed      callsign
- * @property mixed      route_code
- * @property int        route_leg
- * @property bool       has_bid
- * @property Collection field_values
- * @property Collection fares
- * @property Collection subfleets
- * @property int        days
- * @property Distance   distance
- * @property Distance   planned_distance
- * @property int        flight_time
- * @property string     route
- * @property string     dpt_time
- * @property string     arr_time
- * @property string     flight_type
- * @property string     notes
- * @property int        level
- * @property float      load_factor
- * @property float      load_factor_variance
- * @property float      pilot_pay
- * @property Airport    dpt_airport
- * @property Airport    arr_airport
- * @property Airport    alt_airport
- * @property string     dpt_airport_id
- * @property string     arr_airport_id
- * @property string     alt_airport_id
- * @property int        event_id
- * @property int        user_id
- * @property int        active
- * @property Carbon     start_date
- * @property Carbon     end_date
+ * @property string                          $id
+ * @property int                             $airline_id
+ * @property int                             $flight_number
+ * @property string|null                     $callsign
+ * @property string|null                     $route_code
+ * @property int|null                        $route_leg
+ * @property string                          $dpt_airport_id
+ * @property string                          $arr_airport_id
+ * @property string|null                     $alt_airport_id
+ * @property string|null                     $dpt_time
+ * @property string|null                     $arr_time
+ * @property int|null                        $level
+ * @property mixed|null                      $distance
+ * @property int|null                        $flight_time
+ * @property string                          $flight_type
+ * @property float|null                      $load_factor
+ * @property float|null                      $load_factor_variance
+ * @property string|null                     $route
+ * @property float|null                      $pilot_pay
+ * @property string|null                     $notes
+ * @property int|null                        $scheduled
+ * @property int|null                        $days
+ * @property \Illuminate\Support\Carbon|null $start_date
+ * @property \Illuminate\Support\Carbon|null $end_date
+ * @property bool                            $has_bid
+ * @property bool                            $active
+ * @property bool                            $visible
+ * @property int|null                        $event_id
+ * @property int|null                        $user_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property string|null                     $owner_type
+ * @property string|null                     $owner_id
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \App\Models\Airline|null $airline
+ * @property-read \App\Models\Airport|null $alt_airport
+ * @property-read \App\Models\Airport|null $arr_airport
+ * @property-read mixed $atc
+ * @property-read \App\Models\Airport|null $dpt_airport
+ * @property-read \App\Models\Event|null $event
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Fare> $fares
+ * @property-read int|null $fares_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\FlightFieldValue> $field_values
+ * @property-read int|null $field_values_count
+ * @property-read mixed $ident
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent|null $owner
+ * @property-read \App\Models\SimBrief|null $simbrief
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Subfleet> $subfleets
+ * @property-read int|null $subfleets_count
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Database\Factories\FlightFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereAirlineId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereAltAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereArrAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereArrTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereCallsign($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereDays($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereDistance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereDptAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereDptTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereEndDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereFlightNumber($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereFlightTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereFlightType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereHasBid($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereLevel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereLoadFactor($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereLoadFactorVariance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereNotes($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereOwnerId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereOwnerType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight wherePilotPay($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereRoute($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereRouteCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereRouteLeg($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereScheduled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereStartDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight whereVisible($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Flight withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Flight extends Model
 {

--- a/app/Models/FlightField.php
+++ b/app/Models/FlightField.php
@@ -9,9 +9,18 @@ use Illuminate\Support\Str;
 /**
  * Class FlightField
  *
- * @property string name
- * @property string slug
- * @property bool   required
+ * @property int         $id
+ * @property string      $name
+ * @property string|null $slug
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightField whereSlug($value)
+ *
+ * @mixin \Eloquent
  */
 class FlightField extends Model
 {

--- a/app/Models/FlightFieldValue.php
+++ b/app/Models/FlightFieldValue.php
@@ -10,9 +10,27 @@ use Illuminate\Support\Str;
 /**
  * Class FlightFieldValue
  *
- * @property string   flight_id
- * @property string   name
- * @property string   value
+ * @property int                             $id
+ * @property string                          $flight_id
+ * @property string                          $name
+ * @property string|null                     $slug
+ * @property string|null                     $value
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Flight|null $flight
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereFlightId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|FlightFieldValue whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class FlightFieldValue extends Model
 {

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -3,15 +3,32 @@
 namespace App\Models;
 
 use App\Contracts\Model;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 /**
- * @property string $email
- * @property string $token
- * @property int    $usage_count
- * @property int    $usage_limit
- * @property Carbon $expires_at
+ * @property int                             $id
+ * @property string|null                     $email
+ * @property string                          $token
+ * @property int                             $usage_count
+ * @property int|null                        $usage_limit
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read mixed $link
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereExpiresAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereToken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereUsageCount($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Invite whereUsageLimit($value)
+ *
+ * @mixin \Eloquent
  */
 class Invite extends Model
 {

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -21,15 +21,35 @@ use UnexpectedValueException;
 /**
  * Holds various journals, depending on the morphed_type and morphed_id columns
  *
- * @property mixed                         id
- * @property Money  $balance
- * @property string $currency
- * @property Carbon $updated_at
- * @property Carbon $post_date
- * @property Carbon $created_at
- * @property \App\Models\Enums\JournalType type
- * @property mixed                         morphed_type
- * @property mixed                         morphed_id
+ * @property int                             $id
+ * @property int|null                        $ledger_id
+ * @property int                             $type
+ * @property mixed                           $balance
+ * @property string                          $currency
+ * @property string|null                     $morphed_type
+ * @property int|null                        $morphed_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Ledger|null $ledger
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent|null $morphed
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\JournalTransaction> $transactions
+ * @property-read int|null $transactions_count
+ *
+ * @method static \Database\Factories\JournalFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereBalance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereCurrency($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereLedgerId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereMorphedId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereMorphedType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Journal whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Journal extends Model
 {

--- a/app/Models/JournalTransaction.php
+++ b/app/Models/JournalTransaction.php
@@ -13,16 +13,39 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property string  id  UUID type
- * @property string  currency
- * @property string  memo
- * @property string  transaction_group
- * @property string  post_date
- * @property int credit
- * @property int debit
- * @property string  ref_model
- * @property int ref_model_id
- * @property Journal journal
+ * @property string                          $id
+ * @property string|null                     $transaction_group
+ * @property int                             $journal_id
+ * @property int|null                        $credit
+ * @property int|null                        $debit
+ * @property string                          $currency
+ * @property string|null                     $memo
+ * @property array<array-key, mixed>|null    $tags
+ * @property string|null                     $ref_model
+ * @property string|null                     $ref_model_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon      $post_date
+ * @property-read \App\Models\Journal|null $journal
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereCredit($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereCurrency($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereDebit($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereJournalId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereMemo($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction wherePostDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereRefModel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereRefModelId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereTags($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereTransactionGroup($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalTransaction whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class JournalTransaction extends Model
 {

--- a/app/Models/Kvp.php
+++ b/app/Models/Kvp.php
@@ -5,8 +5,16 @@ namespace App\Models;
 use App\Contracts\Model;
 
 /**
- * @property string key
- * @property string value
+ * @property string $key
+ * @property string $value
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Kvp newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Kvp newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Kvp query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Kvp whereKey($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Kvp whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class Kvp extends Model
 {

--- a/app/Models/Ledger.php
+++ b/app/Models/Ledger.php
@@ -9,18 +9,32 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Support\Money;
-use Carbon\Carbon;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
  * Class Ledger
  *
- * @property Money  $balance
- * @property string $currency
- * @property Carbon $updated_at
- * @property Carbon $post_date
- * @property Carbon $created_at
+ * @property int                             $id
+ * @property string                          $name
+ * @property string                          $type
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\JournalTransaction> $journal_transctions
+ * @property-read int|null $journal_transctions_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Journal> $journals
+ * @property-read int|null $journals_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Ledger whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Ledger extends Model
 {

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -3,15 +3,28 @@
 namespace App\Models;
 
 use App\Contracts\Model;
-use Carbon\Carbon;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string name
- * @property bool   enabled
- * @property Carbon created_at
- * @property Carbon updated_at
+ * @property int                             $id
+ * @property string                          $name
+ * @property bool                            $enabled
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module whereEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Module whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Module extends Model
 {

--- a/app/Models/Navdata.php
+++ b/app/Models/Navdata.php
@@ -6,6 +6,27 @@ use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @property string     $id
+ * @property string     $name
+ * @property int        $type
+ * @property float|null $lat
+ * @property float|null $lon
+ * @property float|null $freq
+ *
+ * @method static \Database\Factories\NavdataFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereFreq($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereLat($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereLon($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Navdata whereType($value)
+ *
+ * @mixin \Eloquent
+ */
 class Navdata extends Model
 {
     use HasFactory;

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -9,11 +9,29 @@ use Illuminate\Notifications\Notifiable;
 use Kyslik\ColumnSortable\Sortable;
 
 /**
- * @property int       id
- * @property int|mixed user_id
- * @property string    subject
- * @property string    body
- * @property User      user
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property string                          $subject
+ * @property string                          $body
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
+ * @property-read int|null $notifications_count
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Database\Factories\NewsFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereBody($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereSubject($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|News whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class News extends Model
 {

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -8,16 +8,37 @@ use App\Models\Enums\PageType;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 /**
- * @property int    id
- * @property string name
- * @property string slug
- * @property string icon
- * @property int    type
- * @property bool   public
- * @property bool   enabled
- * @property bool   new_window
- * @property string body
- * @property string link
+ * @property int                             $id
+ * @property string                          $name
+ * @property string                          $slug
+ * @property string|null                     $icon
+ * @property int                             $type
+ * @property bool                            $public
+ * @property bool                            $enabled
+ * @property string|null                     $body
+ * @property string|null                     $link
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property bool                            $new_window
+ * @property-read mixed $url
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereBody($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereIcon($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereLink($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereNewWindow($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page wherePublic($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Page whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Page extends Model
 {

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -5,6 +5,31 @@ namespace App\Models;
 use Spatie\Permission\Models\Permission as SpatiePermission;
 
 /**
- * @method static firstOrCreate(array $array, array $array1)
+ * @property int                             $id
+ * @property string                          $name
+ * @property string                          $guard_name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, SpatiePermission> $permissions
+ * @property-read int|null $permissions_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Permission\Models\Role> $roles
+ * @property-read int|null $roles_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission permission($permissions, $without = false)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission role($roles, $guard = null, $without = false)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission whereGuardName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission withoutPermission($permissions)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Permission withoutRole($roles, $guard = null)
+ *
+ * @mixin \Eloquent
  */
 class Permission extends SpatiePermission {}

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -12,9 +12,6 @@ use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepFieldSource;
 use App\Models\Enums\PirepState;
 use App\Models\Traits\HashIdTrait;
-use App\Support\Units\Distance;
-use App\Support\Units\Fuel;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -22,60 +19,125 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Collection;
 use Kleemans\AttributeEvents;
 use Kyslik\ColumnSortable\Sortable;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string      id
- * @property string      ident
- * @property string      flight_number
- * @property string      route_code
- * @property string      route_leg
- * @property string      flight_type
- * @property int         airline_id
- * @property int         user_id
- * @property int         aircraft_id
- * @property int         event_id
- * @property Aircraft    aircraft
- * @property Airline     airline
- * @property Airport     arr_airport
- * @property string      arr_airport_id
- * @property Airport     dpt_airport
- * @property string      dpt_airport_id
- * @property Airport     alt_airport
- * @property string      alt_airport_id
- * @property Carbon      block_off_time
- * @property Carbon      block_on_time
- * @property int         block_time
- * @property int         flight_time    In minutes
- * @property int         planned_flight_time
- * @property Fuel        block_fuel
- * @property Fuel        fuel_used
- * @property Distance    distance
- * @property Distance    planned_distance
- * @property float       progress_percent
- * @property int         level
- * @property string      route
- * @property int         score
- * @property User        user
- * @property Flight|null flight
- * @property Collection  fields
- * @property string      status
- * @property int         state
- * @property int         source
- * @property string      source_name
- * @property Carbon      submitted_at
- * @property Carbon      created_at
- * @property Carbon      updated_at
- * @property bool        read_only      Attribute
- * @property Acars       position
- * @property Acars[]     acars
- * @property mixed       cancelled
- * @property PirepFare[] $fares
- * @property SimBrief    $simbrief
+ * @property string                          $id
+ * @property int                             $user_id
+ * @property int                             $airline_id
+ * @property int|null                        $aircraft_id
+ * @property int|null                        $event_id
+ * @property string|null                     $flight_id
+ * @property string|null                     $flight_number
+ * @property string|null                     $route_code
+ * @property string|null                     $route_leg
+ * @property string                          $flight_type
+ * @property string                          $dpt_airport_id
+ * @property string                          $arr_airport_id
+ * @property string|null                     $alt_airport_id
+ * @property int|null                        $level
+ * @property mixed|null                      $distance
+ * @property mixed|null                      $planned_distance
+ * @property int|null                        $flight_time
+ * @property int|null                        $planned_flight_time
+ * @property float|null                      $zfw
+ * @property mixed|null                      $block_fuel
+ * @property mixed|null                      $fuel_used
+ * @property float|null                      $landing_rate
+ * @property int|null                        $score
+ * @property string|null                     $route
+ * @property string|null                     $notes
+ * @property int|null                        $source
+ * @property string|null                     $source_name
+ * @property int                             $state
+ * @property string                          $status
+ * @property mixed|null                      $submitted_at
+ * @property mixed|null                      $block_off_time
+ * @property mixed|null                      $block_on_time
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Acars> $acars
+ * @property-read int|null $acars_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Acars> $acars_logs
+ * @property-read int|null $acars_logs_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Acars> $acars_route
+ * @property-read int|null $acars_route_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \App\Models\Aircraft|null $aircraft
+ * @property-read \App\Models\Airline|null $airline
+ * @property-read \App\Models\Airport|null $alt_airport
+ * @property-read \App\Models\Airport|null $arr_airport
+ * @property-read mixed $cancelled
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PirepComment> $comments
+ * @property-read int|null $comments_count
+ * @property-read \App\Models\Airport|null $dpt_airport
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PirepFare> $fares
+ * @property-read int|null $fares_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PirepFieldValue> $field_values
+ * @property-read int|null $field_values_count
+ * @property-read mixed $fields
+ * @property-read \App\Models\Flight|null $flight
+ * @property-read mixed $ident
+ * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
+ * @property-read int|null $notifications_count
+ * @property-read \App\Models\Acars|null $position
+ * @property-read mixed $progress_percent
+ * @property-read mixed $read_only
+ * @property-read \App\Models\SimBrief|null $simbrief
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\JournalTransaction> $transactions
+ * @property-read int|null $transactions_count
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Database\Factories\PirepFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereAircraftId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereAirlineId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereAltAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereArrAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereBlockFuel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereBlockOffTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereBlockOnTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereDistance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereDptAirportId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereFlightId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereFlightNumber($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereFlightTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereFlightType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereFuelUsed($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereLandingRate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereLevel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereNotes($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep wherePlannedDistance($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep wherePlannedFlightTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereRoute($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereRouteCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereRouteLeg($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereScore($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereSource($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereSourceName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereState($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereStatus($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereSubmittedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep whereZfw($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Pirep withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Pirep extends Model
 {

--- a/app/Models/PirepComment.php
+++ b/app/Models/PirepComment.php
@@ -3,16 +3,29 @@
 namespace App\Models;
 
 use App\Contracts\Model;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property string $pirep_id
- * @property string $comment
- * @property int    $user_id
- * @property Pirep  $pirep
- * @property User   $user
- * @property Carbon $created_at
+ * @property int                             $id
+ * @property string                          $pirep_id
+ * @property int                             $user_id
+ * @property string                          $comment
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Pirep|null $pirep
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment whereComment($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment wherePirepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepComment whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class PirepComment extends Model
 {

--- a/app/Models/PirepFare.php
+++ b/app/Models/PirepFare.php
@@ -3,22 +3,39 @@
 namespace App\Models;
 
 use App\Contracts\Model;
-use App\Models\Enums\FareType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property int       id
- * @property string    pirep_id
- * @property int       fare_id
- * @property string    code
- * @property string    name
- * @property int       count
- * @property float     price
- * @property float $cost
- * @property int   $capacity
- * @property Pirep     pirep
- * @property Fare|null fare
- * @property FareType  type
+ * @property int         $id
+ * @property string      $pirep_id
+ * @property int|null    $fare_id
+ * @property int|null    $count
+ * @property string|null $code
+ * @property string|null $name
+ * @property float|null  $price
+ * @property float|null  $cost
+ * @property int|null    $capacity
+ * @property int|null    $type
+ * @property string|null $deleted_at
+ * @property-read \App\Models\Fare|null $fare
+ * @property-read \App\Models\Pirep|null $pirep
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereCapacity($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereCost($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereCount($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereFareId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare wherePirepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare wherePrice($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFare whereType($value)
+ *
+ * @mixin \Eloquent
  */
 class PirepFare extends Model
 {

--- a/app/Models/PirepField.php
+++ b/app/Models/PirepField.php
@@ -9,8 +9,26 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string name
- * @property string slug
+ * @property int         $id
+ * @property string      $name
+ * @property string|null $slug
+ * @property string|null $description
+ * @property bool|null   $required
+ * @property int|null    $pirep_source
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField wherePirepSource($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField whereRequired($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepField whereSlug($value)
+ *
+ * @mixin \Eloquent
  */
 class PirepField extends Model
 {

--- a/app/Models/PirepFieldValue.php
+++ b/app/Models/PirepFieldValue.php
@@ -9,14 +9,30 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 
 /**
- * @property string pirep_id
- * @property string name
- * @property string slug
- * @property string value
- * @property string source
- * @property Pirep  pirep
+ * @property int                             $id
+ * @property string                          $pirep_id
+ * @property string                          $name
+ * @property string|null                     $slug
+ * @property string|null                     $value
+ * @property int                             $source
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Pirep|null $pirep
+ * @property-read mixed $read_only
  *
- * @method static updateOrCreate(array $array, array $array1)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue wherePirepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereSource($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PirepFieldValue whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class PirepFieldValue extends Model
 {

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -13,13 +13,51 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string name
- * @property int    hours
- * @property float  manual_base_pay_rate
- * @property float  acars_base_pay_rate
- * @property bool   auto_promote
- * @property bool   auto_approve_acars
- * @property bool   auto_approve_manual
+ * @property int                             $id
+ * @property string                          $name
+ * @property string|null                     $image_url
+ * @property int                             $hours
+ * @property string|null                     $acars_base_pay_rate
+ * @property string|null                     $manual_base_pay_rate
+ * @property bool|null                       $auto_approve_acars
+ * @property bool|null                       $auto_approve_manual
+ * @property bool|null                       $auto_promote
+ * @property int|null                        $auto_approve_above_score
+ * @property int|null                        $auto_approve_score
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Subfleet> $subfleets
+ * @property-read int|null $subfleets_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Database\Factories\RankFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAcarsBasePayRate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAutoApproveAboveScore($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAutoApproveAcars($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAutoApproveManual($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAutoApproveScore($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereAutoPromote($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereHours($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereImageUrl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereManualBasePayRate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Rank withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Rank extends Model
 {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -9,12 +9,33 @@ use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Permission\Models\Role as SpatieRole;
 
 /**
- * @property int id
- * @property string name
- * @property string guard_name
- * @property bool disable_activity_checks
+ * @property int                             $id
+ * @property string                          $name
+ * @property string                          $guard_name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property int                             $disable_activity_checks
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Permission\Models\Permission> $permissions
+ * @property-read int|null $permissions_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
  *
- * @mixin Builder
+ * @method static \Database\Factories\RoleFactory                    factory($count = null, $state = [])
+ * @method static Builder<static>|Role                               newModelQuery()
+ * @method static Builder<static>|Role                               newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Role permission($permissions, $without = false)
+ * @method static Builder<static>|Role                               query()
+ * @method static Builder<static>|Role                               whereCreatedAt($value)
+ * @method static Builder<static>|Role                               whereDisableActivityChecks($value)
+ * @method static Builder<static>|Role                               whereGuardName($value)
+ * @method static Builder<static>|Role                               whereId($value)
+ * @method static Builder<static>|Role                               whereName($value)
+ * @method static Builder<static>|Role                               whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Role withoutPermission($permissions)
+ *
+ * @mixin \Eloquent
  */
 class Role extends SpatieRole
 {

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -8,15 +8,40 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property string id
- * @property string name
- * @property string key
- * @property string value
- * @property string group
- * @property string type
- * @property string options
- * @property int    order
- * @property string description
+ * @property string                          $id
+ * @property int                             $offset
+ * @property int                             $order
+ * @property string                          $key
+ * @property string                          $name
+ * @property string                          $value
+ * @property string|null                     $default
+ * @property string|null                     $group
+ * @property string|null                     $type
+ * @property string|null                     $options
+ * @property string|null                     $description
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereDefault($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereGroup($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereKey($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereOffset($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereOptions($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Setting whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class Setting extends Model
 {

--- a/app/Models/SimBrief.php
+++ b/app/Models/SimBrief.php
@@ -6,25 +6,42 @@ use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Collection;
 
 /**
- * @property string      $id                   The Simbrief OFP ID
- * @property int         $user_id              The user that generated this
- * @property string      $flight_id            Optional, if attached to a flight, removed if attached to PIREP
- * @property string      $pirep_id             Optional, if attached to a PIREP, removed if attached to flight
- * @property string      $aircraft_id          The aircraft this is for
- * @property string      $acars_xml
- * @property string      $ofp_xml
- * @property string      $ofp_html
- * @property string      $fare_data            JSON string of the fare data that was generated
- * @property Collection  $images
- * @property Collection  $files
- * @property Flight      $flight
- * @property User        $user
- * @property SimBriefXML $xml
- * @property Aircraft    $aircraft
- * @property string      $acars_flightplan_url
+ * @property string                          $id
+ * @property int                             $user_id
+ * @property string|null                     $flight_id
+ * @property string|null                     $pirep_id
+ * @property int|null                        $aircraft_id
+ * @property string                          $acars_xml
+ * @property string                          $ofp_xml
+ * @property string|null                     $fare_data
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Aircraft|null $aircraft
+ * @property-read mixed $files
+ * @property-read \App\Models\Flight|null $flight
+ * @property-read mixed $images
+ * @property-read \App\Models\Pirep|null $pirep
+ * @property-read \App\Models\User|null $user
+ * @property-read mixed $xml
+ *
+ * @method static \Database\Factories\SimBriefFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereAcarsXml($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereAircraftId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereFareData($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereFlightId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereOfpXml($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief wherePirepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBrief whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class SimBrief extends Model
 {

--- a/app/Models/SimBriefAircraft.php
+++ b/app/Models/SimBriefAircraft.php
@@ -5,6 +5,28 @@ namespace App\Models;
 use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property int                             $id
+ * @property string                          $icao
+ * @property string                          $name
+ * @property string|null                     $details
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SimBriefAirframe> $sbairframes
+ * @property-read int|null $sbairframes_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereDetails($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereIcao($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAircraft whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
 class SimBriefAircraft extends Model
 {
     public $table = 'simbrief_aircraft';

--- a/app/Models/SimBriefAirframe.php
+++ b/app/Models/SimBriefAirframe.php
@@ -5,6 +5,33 @@ namespace App\Models;
 use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int                             $id
+ * @property string                          $icao
+ * @property string                          $name
+ * @property string|null                     $airframe_id
+ * @property int|null                        $source
+ * @property string|null                     $details
+ * @property string|null                     $options
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\SimBriefAircraft|null $sbaircraft
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereAirframeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereDetails($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereIcao($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereOptions($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereSource($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefAirframe whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
 class SimBriefAirframe extends Model
 {
     public $table = 'simbrief_airframes';

--- a/app/Models/SimBriefLayout.php
+++ b/app/Models/SimBriefLayout.php
@@ -4,6 +4,24 @@ namespace App\Models;
 
 use App\Contracts\Model;
 
+/**
+ * @property string                          $id
+ * @property string                          $name
+ * @property string                          $name_long
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout whereNameLong($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SimBriefLayout whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
 class SimBriefLayout extends Model
 {
     public $table = 'simbrief_layouts';

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -18,20 +18,68 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
- * @property int        id
- * @property string     type
- * @property string     simbrief_type
- * @property string     name
- * @property int        airline_id
- * @property int        hub_id
- * @property string     ground_handling_multiplier
- * @property Fare[]     fares
- * @property float      cost_block_hour
- * @property float      cost_delay_minute
- * @property Airline    airline
- * @property Airport    home
- * @property int        fuel_type
- * @property Aircraft[] $aircraft
+ * @property int                             $id
+ * @property int|null                        $airline_id
+ * @property string|null                     $hub_id
+ * @property string                          $type
+ * @property string|null                     $simbrief_type
+ * @property string                          $name
+ * @property float|null                      $cost_block_hour
+ * @property float|null                      $cost_delay_minute
+ * @property int|null                        $fuel_type
+ * @property float|null                      $ground_handling_multiplier
+ * @property float|null                      $cargo_capacity
+ * @property float|null                      $fuel_capacity
+ * @property float|null                      $gross_weight
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Aircraft> $aircraft
+ * @property-read int|null $aircraft_count
+ * @property-read \App\Models\Airline|null $airline
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Expense> $expenses
+ * @property-read int|null $expenses_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Fare> $fares
+ * @property-read int|null $fares_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\File> $files
+ * @property-read int|null $files_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Flight> $flights
+ * @property-read int|null $flights_count
+ * @property-read \App\Models\Airport|null $home
+ * @property-read \App\Models\Airport|null $hub
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Rank> $ranks
+ * @property-read int|null $ranks_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Typerating> $typeratings
+ * @property-read int|null $typeratings_count
+ *
+ * @method static \Database\Factories\SubfleetFactory                    factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereAirlineId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereCargoCapacity($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereCostBlockHour($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereCostDelayMinute($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereFuelCapacity($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereFuelType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereGrossWeight($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereGroundHandlingMultiplier($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereHubId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereSimbriefType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Subfleet withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class Subfleet extends Model
 {

--- a/app/Models/Typerating.php
+++ b/app/Models/Typerating.php
@@ -8,6 +8,37 @@ use Kyslik\ColumnSortable\Sortable;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+/**
+ * @property int                             $id
+ * @property string                          $name
+ * @property string                          $type
+ * @property string|null                     $description
+ * @property string|null                     $image_url
+ * @property int                             $active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Subfleet> $subfleets
+ * @property-read int|null $subfleets_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereImageUrl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Typerating whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
 class Typerating extends Model
 {
     use LogsActivity;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,53 +25,122 @@ use Spatie\Permission\Traits\HasRoles;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 
 /**
- * @property int              id
- * @property int              pilot_id
- * @property int              airline_id
- * @property string           callsign
- * @property string           name
- * @property string           name_private Only first name, rest are initials
- * @property string           email
- * @property string           password
- * @property string           api_key
- * @property mixed            timezone
- * @property string           ident
- * @property string           atc
- * @property string           curr_airport_id
- * @property string           home_airport_id
- * @property string           avatar
- * @property Airline          airline
- * @property int              flights
- * @property int              flight_time
- * @property int              transfer_time
- * @property string           remember_token
- * @property \Carbon\Carbon   created_at
- * @property \Carbon\Carbon   updated_at
- * @property Rank             rank
- * @property Journal          journal
- * @property int              rank_id
- * @property string           discord_id
- * @property string           vatsim_id
- * @property string           ivao_id
- * @property int              state
- * @property string           last_ip
- * @property \Carbon\Carbon   lastlogin_at
- * @property bool             opt_in
- * @property Pirep[]          pireps
- * @property string           last_pirep_id
- * @property Pirep            last_pirep
- * @property UserFieldValue[] fields
- * @property UserOAuthToken[] oauth_tokens
- * @property Role[]           roles
- * @property Subfleet[]       subfleets
- * @property TypeRating[]     typeratings
- * @property Airport          home_airport
- * @property Airport          current_airport
- * @property Airport          location
- * @property Bid[]            bids
+ * @property int                             $id
+ * @property int|null                        $pilot_id
+ * @property string|null                     $callsign
+ * @property string|null                     $name
+ * @property string                          $email
+ * @property string                          $password
+ * @property string|null                     $api_key
+ * @property int                             $airline_id
+ * @property int|null                        $rank_id
+ * @property string                          $discord_id
+ * @property string                          $discord_private_channel_id
+ * @property string                          $vatsim_id
+ * @property string                          $ivao_id
+ * @property string|null                     $country
+ * @property string|null                     $home_airport_id
+ * @property string|null                     $curr_airport_id
+ * @property string|null                     $last_pirep_id
+ * @property int                             $flights
+ * @property int|null                        $flight_time
+ * @property int|null                        $transfer_time
+ * @property string|null                     $avatar
+ * @property string|null                     $timezone
+ * @property int|null                        $status
+ * @property int|null                        $state
+ * @property bool|null                       $toc_accepted
+ * @property bool|null                       $opt_in
+ * @property int|null                        $active
+ * @property string|null                     $last_ip
+ * @property \Illuminate\Support\Carbon|null $lastlogin_at
+ * @property string|null                     $remember_token
+ * @property string|null                     $notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property \Illuminate\Support\Carbon|null $email_verified_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Activitylog\Models\Activity> $activities
+ * @property-read int|null $activities_count
+ * @property-read \App\Models\Airline|null $airline
+ * @property-read mixed $atc
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Award> $awards
+ * @property-read int|null $awards_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Bid> $bids
+ * @property-read int|null $bids_count
+ * @property-read \App\Models\Airport|null $current_airport
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\UserFieldValue> $fields
+ * @property-read int|null $fields_count
+ * @property-read \App\Models\Airport|null $home_airport
+ * @property-read mixed $ident
+ * @property-read \App\Models\Journal|null $journal
+ * @property-read \App\Models\Pirep|null $last_pirep
+ * @property-read \App\Models\Airport|null $location
+ * @property-read mixed $name_private
+ * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
+ * @property-read int|null $notifications_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\UserOAuthToken> $oauth_tokens
+ * @property-read int|null $oauth_tokens_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Permission\Models\Permission> $permissions
+ * @property-read int|null $permissions_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Pirep> $pireps
+ * @property-read int|null $pireps_count
+ * @property-read \App\Models\Rank|null $rank
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Spatie\Permission\Models\Role> $roles
+ * @property-read int|null $roles_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Typerating> $typeratings
+ * @property-read int|null $typeratings_count
+ * @property mixed $tz
  *
- * @mixin Builder
- * @mixin Notifiable
+ * @method static \Database\Factories\UserFactory factory($count = null, $state = [])
+ * @method static Builder<static>|User            newModelQuery()
+ * @method static Builder<static>|User            newQuery()
+ * @method static Builder<static>|User            onlyTrashed()
+ * @method static Builder<static>|User            permission($permissions, $without = false)
+ * @method static Builder<static>|User            query()
+ * @method static Builder<static>|User            role($roles, $guard = null, $without = false)
+ * @method static Builder<static>|User            sortable($defaultParameters = null)
+ * @method static Builder<static>|User            whereActive($value)
+ * @method static Builder<static>|User            whereAirlineId($value)
+ * @method static Builder<static>|User            whereApiKey($value)
+ * @method static Builder<static>|User            whereAvatar($value)
+ * @method static Builder<static>|User            whereCallsign($value)
+ * @method static Builder<static>|User            whereCountry($value)
+ * @method static Builder<static>|User            whereCreatedAt($value)
+ * @method static Builder<static>|User            whereCurrAirportId($value)
+ * @method static Builder<static>|User            whereDeletedAt($value)
+ * @method static Builder<static>|User            whereDiscordId($value)
+ * @method static Builder<static>|User            whereDiscordPrivateChannelId($value)
+ * @method static Builder<static>|User            whereEmail($value)
+ * @method static Builder<static>|User            whereEmailVerifiedAt($value)
+ * @method static Builder<static>|User            whereFlightTime($value)
+ * @method static Builder<static>|User            whereFlights($value)
+ * @method static Builder<static>|User            whereHomeAirportId($value)
+ * @method static Builder<static>|User            whereId($value)
+ * @method static Builder<static>|User            whereIvaoId($value)
+ * @method static Builder<static>|User            whereLastIp($value)
+ * @method static Builder<static>|User            whereLastPirepId($value)
+ * @method static Builder<static>|User            whereLastloginAt($value)
+ * @method static Builder<static>|User            whereName($value)
+ * @method static Builder<static>|User            whereNotes($value)
+ * @method static Builder<static>|User            whereOptIn($value)
+ * @method static Builder<static>|User            wherePassword($value)
+ * @method static Builder<static>|User            wherePilotId($value)
+ * @method static Builder<static>|User            whereRankId($value)
+ * @method static Builder<static>|User            whereRememberToken($value)
+ * @method static Builder<static>|User            whereState($value)
+ * @method static Builder<static>|User            whereStatus($value)
+ * @method static Builder<static>|User            whereTimezone($value)
+ * @method static Builder<static>|User            whereTocAccepted($value)
+ * @method static Builder<static>|User            whereTransferTime($value)
+ * @method static Builder<static>|User            whereUpdatedAt($value)
+ * @method static Builder<static>|User            whereVatsimId($value)
+ * @method static Builder<static>|User            withTrashed(bool $withTrashed = true)
+ * @method static Builder<static>|User            withoutPermission($permissions)
+ * @method static Builder<static>|User            withoutRole($roles, $guard = null)
+ * @method static Builder<static>|User            withoutTrashed()
+ *
+ * @mixin \Eloquent
  */
 class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerifyEmail
 {

--- a/app/Models/UserAward.php
+++ b/app/Models/UserAward.php
@@ -8,6 +8,29 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Notifications\Notifiable;
 use Kyslik\ColumnSortable\Sortable;
 
+/**
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property int                             $award_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Award|null $award
+ * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
+ * @property-read int|null $notifications_count
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward sortable($defaultParameters = null)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward whereAwardId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserAward whereUserId($value)
+ *
+ * @mixin \Eloquent
+ */
 class UserAward extends Model
 {
     use Notifiable;

--- a/app/Models/UserField.php
+++ b/app/Models/UserField.php
@@ -7,12 +7,33 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Str;
 
 /**
- * @property string name
- * @property string slug
- * @property string value  Only set if "squashed"
- * @property bool   show_on_registration
- * @property bool   required
- * @property bool   private
+ * @property int                             $id
+ * @property string                          $name
+ * @property string|null                     $description
+ * @property bool|null                       $show_on_registration
+ * @property bool|null                       $required
+ * @property bool|null                       $private
+ * @property bool                            $internal
+ * @property bool|null                       $active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read mixed $slug
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereInternal($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField wherePrivate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereRequired($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereShowOnRegistration($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserField whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class UserField extends Model
 {

--- a/app/Models/UserFieldValue.php
+++ b/app/Models/UserFieldValue.php
@@ -7,10 +7,27 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property string    name
- * @property string    value
- * @property UserField field
- * @property User      user
+ * @property int                             $id
+ * @property int                             $user_field_id
+ * @property string                          $user_id
+ * @property string|null                     $value
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\UserField|null $field
+ * @property-read mixed $name
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereUserFieldId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserFieldValue whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class UserFieldValue extends Model
 {

--- a/app/Models/UserOAuthToken.php
+++ b/app/Models/UserOAuthToken.php
@@ -7,12 +7,30 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property int            user_id
- * @property User           user
- * @property string         provider
- * @property string         token
- * @property string         refresh_token
- * @property \Carbon\Carbon expires_at
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property string                          $provider
+ * @property string                          $token
+ * @property string                          $refresh_token
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read mixed $is_expired
+ * @property-read \App\Models\User|null $user
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereExpiresAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereProvider($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereRefreshToken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereToken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|UserOAuthToken whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class UserOAuthToken extends Model
 {

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,8 @@
         "pestphp/pest-plugin-laravel": "^3.2",
         "pestphp/pest-plugin-livewire": "^3.0",
         "pestphp/pest-plugin-watch": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.1"
+        "pestphp/pest-plugin-arch": "^3.1",
+        "barryvdh/laravel-ide-helper": "^3.6"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,11 @@
             "@php artisan filament:upgrade",
             ".hooks/setup-git-hooks.sh"
         ],
+        "post-update-cmd": [
+          "Illuminate\\Foundation\\ComposerScripts::postUpdate",
+          "@php artisan ide-helper:generate",
+          "@php artisan ide-helper:meta"
+        ],
         "pint": "pint --dirty",
         "test": "phpunit",
         "dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e1f7e1686ec6d03deb2b94dd082f11e",
+    "content-hash": "60c24d732ae4570e2882352c1c01a30b",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -16127,6 +16127,152 @@
                 }
             ],
             "time": "2025-02-25T15:25:22+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-ide-helper",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+                "reference": "8d00250cba25728373e92c1d8dcebcbf64623d29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/8d00250cba25728373e92c1d8dcebcbf64623d29",
+                "reference": "8d00250cba25728373e92c1d8dcebcbf64623d29",
+                "shasum": ""
+            },
+            "require": {
+                "barryvdh/reflection-docblock": "^2.4",
+                "composer/class-map-generator": "^1.0",
+                "ext-json": "*",
+                "illuminate/console": "^11.15 || ^12",
+                "illuminate/database": "^11.15 || ^12",
+                "illuminate/filesystem": "^11.15 || ^12",
+                "illuminate/support": "^11.15 || ^12",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "friendsofphp/php-cs-fixer": "^3",
+                "illuminate/config": "^11.15 || ^12",
+                "illuminate/view": "^11.15 || ^12",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^9.2 || ^10",
+                "phpunit/phpunit": "^10.5 || ^11.5.3",
+                "spatie/phpunit-snapshot-assertions": "^4 || ^5",
+                "vimeo/psalm": "^5.4",
+                "vlucas/phpdotenv": "^5"
+            },
+            "suggest": {
+                "illuminate/events": "Required for automatic helper generation (^6|^7|^8|^9|^10|^11)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\LaravelIdeHelper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
+            "keywords": [
+                "autocomplete",
+                "codeintel",
+                "dev",
+                "helper",
+                "ide",
+                "laravel",
+                "netbeans",
+                "phpdoc",
+                "phpstorm",
+                "sublime"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-ide-helper/issues",
+                "source": "https://github.com/barryvdh/laravel-ide-helper/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T20:11:57+00:00"
+        },
+        {
+            "name": "barryvdh/reflection-docblock",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
+                "reference": "d103774cbe7e94ddee7e4870f97f727b43fe7201"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/d103774cbe7e94ddee7e4870f97f727b43fe7201",
+                "reference": "d103774cbe7e94ddee7e4870f97f727b43fe7201",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.14|^9"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Barryvdh": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.4.0"
+            },
+            "time": "2025-07-17T06:07:30+00:00"
         },
         {
             "name": "brianium/paratest",

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,17 +1,115 @@
 <?php
 
 return [
+
     /*
     |--------------------------------------------------------------------------
-    | Filename & Format
+    | Filename
     |--------------------------------------------------------------------------
     |
-    | The default filename (without extension) and the format (php or json)
+    | The default filename.
     |
     */
 
-    'filename' => '_ide_helper',
-    'format'   => 'php',
+    'filename' => '_ide_helper.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models filename
+    |--------------------------------------------------------------------------
+    |
+    | The default filename for the models helper file.
+    |
+    */
+
+    'models_filename' => '_ide_helper_models.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | PhpStorm meta filename
+    |--------------------------------------------------------------------------
+    |
+    | PhpStorm also supports the directory `.phpstorm.meta.php/` with arbitrary
+    | files in it, should you need additional files for your project; e.g.
+    | `.phpstorm.meta.php/laravel_ide_Helper.php'.
+    |
+    */
+    'meta_filename' => '.phpstorm.meta.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fluent helpers
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate commonly used Fluent methods.
+    |
+    */
+
+    'include_fluent' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Factory builders
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate factory generators for better factory()
+    | method auto-completion.
+    |
+    | Deprecated for Laravel 8 or latest.
+    |
+    */
+
+    'include_factory_builders' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write model magic methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write magic methods of model.
+    |
+    */
+
+    'write_model_magic_where' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write model external Eloquent builder methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write external Eloquent builder methods.
+    |
+    */
+
+    'write_model_external_builder_methods' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write model relation count and exists properties
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable writing of relation count and exists properties
+    | to model DocBlocks.
+    |
+    */
+
+    'write_model_relation_count_properties'  => true,
+    'write_model_relation_exists_properties' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write Eloquent model mixins
+    |--------------------------------------------------------------------------
+    |
+    | This will add the necessary DocBlock mixins to the model class
+    | contained in the Laravel framework. This helps the IDE with
+    | auto-completion.
+    |
+    | Please be aware that this setting changes a file within the /vendor directory.
+    |
+    */
+
+    'write_eloquent_model_mixins' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -27,6 +125,7 @@ return [
 
     'helper_files' => [
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
+        base_path().'/vendor/laravel/framework/src/Illuminate/Foundation/helpers.php',
     ],
 
     /*
@@ -37,10 +136,41 @@ return [
     | Define in which directories the ide-helper:models command should look
     | for models.
     |
+    | glob patterns are supported to easier reach models in sub-directories,
+    | e.g. `app/Services/* /Models` (without the space).
+    |
     */
 
     'model_locations' => [
-        // 'app/Models',
+        'app',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models to ignore
+    |--------------------------------------------------------------------------
+    |
+    | Define which models should be ignored.
+    |
+    */
+
+    'ignored_models' => [
+        // App\MyModel::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models hooks
+    |--------------------------------------------------------------------------
+    |
+    | Define which hook classes you want to run for models to add custom information.
+    |
+    | Hooks should implement Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface.
+    |
+    */
+
+    'model_hooks' => [
+        // App\Support\IdeHelper\MyModelHook::class
     ],
 
     /*
@@ -48,7 +178,7 @@ return [
     | Extra classes
     |--------------------------------------------------------------------------
     |
-    | These implementations are not really extended, but called with magic functions
+    | These implementations are not really extended, but called with magic functions.
     |
     */
 
@@ -57,18 +187,7 @@ return [
         'Session'  => ['Illuminate\Session\Store'],
     ],
 
-    'magic' => [
-        'Log' => [
-            'debug'     => 'Monolog\Logger::addDebug',
-            'info'      => 'Monolog\Logger::addInfo',
-            'notice'    => 'Monolog\Logger::addNotice',
-            'warning'   => 'Monolog\Logger::addWarning',
-            'error'     => 'Monolog\Logger::addError',
-            'critical'  => 'Monolog\Logger::addCritical',
-            'alert'     => 'Monolog\Logger::addAlert',
-            'emergency' => 'Monolog\Logger::addEmergency',
-        ],
-    ],
+    'magic' => [],
 
     /*
     |--------------------------------------------------------------------------
@@ -81,37 +200,7 @@ return [
     */
 
     'interfaces' => [
-
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Support for custom DB types
-    |--------------------------------------------------------------------------
-    |
-    | This setting allow you to map any custom database type (that you may have
-    | created using CREATE TYPE statement or imported using database plugin
-    | / extension to a Doctrine type.
-    |
-    | Each key in this array is a name of the Doctrine2 DBAL Platform. Currently valid names are:
-    | 'postgresql', 'db2', 'drizzle', 'mysql', 'oracle', 'sqlanywhere', 'sqlite', 'mssql'
-    |
-    | This name is returned by getName() method of the specific Doctrine/DBAL/Platforms/AbstractPlatform descendant
-    |
-    | The value of the array is an array of type mappings. Key is the name of the custom type,
-    | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
-    | our case it is 'json_array'. Doctrine types are listed here:
-    | http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html
-    |
-    | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
-    |
-    | "postgresql" => array(
-    |       "jsonb" => "json_array",
-    |  ),
-    |
-    */
-    'custom_db_types' => [
-
+        // App\MyInterface::class => App\MyImplementation::class,
     ],
 
     /*
@@ -127,17 +216,139 @@ return [
      |
      | For example, normally you would see this:
      |
-     |  * @property \Carbon\Carbon $created_at
-     |  * @property \Carbon\Carbon $updated_at
+     |  * @property \Illuminate\Support\Carbon $created_at
+     |  * @property \Illuminate\Support\Carbon $updated_at
      |
      | With this enabled, the properties will be this:
      |
-     |  * @property \Carbon\Carbon $createdAt
-     |  * @property \Carbon\Carbon $updatedAt
+     |  * @property \Illuminate\Support\Carbon $createdAt
+     |  * @property \Illuminate\Support\Carbon $updatedAt
      |
      | Note, it is currently an all-or-nothing option.
      |
      */
     'model_camel_case_properties' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Property casts
+    |--------------------------------------------------------------------------
+    |
+    | Cast the given "real type" to the given "type".
+    |
+    */
+    'type_overrides' => [
+        'integer' => 'int',
+        'boolean' => 'bool',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Include DocBlocks from classes
+    |--------------------------------------------------------------------------
+    |
+    | Include DocBlocks from classes to allow additional code inspection for
+    | magic methods and properties.
+    |
+    */
+    'include_class_docblocks' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force FQN usage
+    |--------------------------------------------------------------------------
+    |
+    | Use the fully qualified (class) name in DocBlocks,
+    | even if the class exists in the same namespace
+    | or there is an import (use className) of the class.
+    |
+    */
+    'force_fqn' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Use generics syntax
+    |--------------------------------------------------------------------------
+    |
+    | Use generics syntax within DocBlocks,
+    | e.g. `Collection<User>` instead of `Collection|User[]`.
+    |
+    */
+    'use_generics_annotations' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default return types for macros
+    |--------------------------------------------------------------------------
+    |
+    | Define default return types for macros without explicit return types.
+    | e.g. `\Illuminate\Database\Query\Builder::class => 'static'`,
+    |      `\Illuminate\Support\Str::class => 'string'`
+    |
+    */
+    'macro_default_return_types' => [
+        Illuminate\Http\Client\Factory::class => Illuminate\Http\Client\PendingRequest::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Additional relation types
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes it's needed to create custom relation types. The key of the array
+    | is the relationship method name. The value of the array is the fully-qualified
+    | class name of the relationship, e.g. `'relationName' => RelationShipClass::class`.
+    |
+    */
+    'additional_relation_types' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Additional relation return types
+    |--------------------------------------------------------------------------
+    |
+    | When using custom relation types its possible for the class name to not contain
+    | the proper return type of the relation. The key of the array is the relationship
+    | method name. The value of the array is the return type of the relation ('many'
+    | or 'morphTo').
+    | e.g. `'relationName' => 'many'`.
+    |
+    */
+    'additional_relation_return_types' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enforce nullable Eloquent relationships on not null columns
+    |--------------------------------------------------------------------------
+    |
+    | When set to true (default), this option enforces nullable Eloquent relationships.
+    | However, in cases where the application logic ensures the presence of related
+    | records it may be desirable to set this option to false to avoid unwanted null warnings.
+    |
+    | Default: true
+    | A not null column with no foreign key constraint will have a "nullable" relationship.
+    |  * @property int $not_null_column_with_no_foreign_key_constraint
+    |  * @property-read BelongsToVariation|null $notNullColumnWithNoForeignKeyConstraint
+    |
+    | Option: false
+    | A not null column with no foreign key constraint will have a "not nullable" relationship.
+    |  * @property int $not_null_column_with_no_foreign_key_constraint
+    |  * @property-read BelongsToVariation $notNullColumnWithNoForeignKeyConstraint
+    |
+    */
+
+    'enforce_nullable_relationships' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Run artisan commands after migrations to generate model helpers
+    |--------------------------------------------------------------------------
+    |
+    | The specified commands should run after migrations are finished running.
+    |
+    */
+    'post_migrate' => [
+        // 'ide-helper:models --nowrite',
+    ],
 
 ];


### PR DESCRIPTION
This PR reintroduces ide-helper, a tool that generates the _ide_helper.php file and PHPDocs for models. This greatly improves IDE autocompletion and the overall understanding of the codebase.