### PR TITLE
[V8.x] Fix transfer_time conversion on user edit page

### DIFF
--- a/app/Filament/Resources/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/Users/Pages/EditUser.php
@@ -37,6 +37,7 @@ class EditUser extends EditRecord
     {
         $data['name'] = $this->record->name;
         $data['email'] = $this->record->email;
+        $data['transfer_time'] = $this->record->transfer_time / 60;
 
         return $data;
     }
@@ -48,6 +49,8 @@ class EditUser extends EditRecord
         } else {
             unset($data['password']);
         }
+
+        $data['transfer_time'] *= 60;
 
         return $data;
     }


### PR DESCRIPTION
The transfer_time is saved on database as minutes as of v7.x, on the filament admin panel, the edit page is treating minutes as hours, this PR fixes that, realizing the conversion before showing the form and before saving the data.