### PR TITLE
[8.x] feat(flights): split settings into 'only allow flights from current' and 'only show flights from current'

### DIFF
--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -72,7 +72,7 @@ class FlightController extends Controller
         }
 
         // default restrictions on the flights shown. Handle search differently
-        if (setting('pilots.only_flights_from_current')) {
+        if (setting('pilots.only_show_flights_from_current')) {
             $where['dpt_airport_id'] = $user->curr_airport_id;
         }
 

--- a/database/seeders/settings.yml
+++ b/database/seeders/settings.yml
@@ -453,12 +453,19 @@
   type: boolean
   description: 'Pilots can only select hubs as their home airport'
 - key: pilots.only_flights_from_current
-  name: 'Flights from Current'
+  name: 'Only allow flights from Current'
   group: pilots
   value: false
   options: ''
   type: boolean
-  description: 'Only show/allow flights from their current location'
+  description: 'Only allow flights from their current location'
+- key: pilots.only_show_flights_from_current
+  name: 'Only show flights from Current'
+  group: pilots
+  value: false
+  options: ''
+  type: boolean
+  description: 'Only show flights from their current location'
 - key: pilots.auto_leave_days
   name: 'Pilot to ON LEAVE days'
   group: pilots

--- a/resources/views/layouts/beta/flights/table.blade.php
+++ b/resources/views/layouts/beta/flights/table.blade.php
@@ -91,38 +91,40 @@
       </div>
       <div class="row">
         <div class="col-sm-12 text-right">
-          @if ($acars_plugin)
-            @if (isset($saved[$flight->id]))
-              <a href="vmsacars:bid/{{ $saved[$flight->id] }}" class="btn btn-sm btn-outline-primary">Load in vmsACARS</a>
-            @else
-              <a href="vmsacars:flight/{{ $flight->id }}" class="btn btn-sm btn-outline-primary">Load in vmsACARS</a>
-            @endif
-          @endif
-          <!-- Simbrief enabled -->
-          @if ($simbrief !== false)
-            <!-- If this flight has a briefing, show the link to view it-->
-            @if ($flight->simbrief && $flight->simbrief->user_id === $user->id)
-              <a href="{{ route('frontend.simbrief.briefing', $flight->simbrief->id) }}"
-                 class="btn btn-sm btn-outline-primary">
-                View Simbrief Flight Plan
-              </a>
-            @else
-              <!-- Show button if the bids-only is disable, or if bids-only is enabled, they've saved it -->
-              @if ($simbrief_bids === false || ($simbrief_bids === true && isset($saved[$flight->id])))
-                @php
-                  $aircraft_id = isset($saved[$flight->id]) ? App\Models\Bid::find($saved[$flight->id])->aircraft_id : null;
-                @endphp
-                <a href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}@if($aircraft_id)&aircraft_id={{ $aircraft_id }} @endif"
-                   class="btn btn-sm btn-outline-primary">
-                  Create Simbrief Flight Plan
-                </a>
+          @if (!setting('pilots.only_flights_from_current') || $flight->dpt_airport_id === $user->current_airport->icao)
+            @if ($acars_plugin)
+              @if (isset($saved[$flight->id]))
+                <a href="vmsacars:bid/{{ $saved[$flight->id] }}" class="btn btn-sm btn-outline-primary">Load in vmsACARS</a>
+              @else
+                <a href="vmsacars:flight/{{ $flight->id }}" class="btn btn-sm btn-outline-primary">Load in vmsACARS</a>
               @endif
-            @endif
+             @endif
+            <!-- Simbrief enabled -->
+            @if ($simbrief !== false)
+              <!-- If this flight has a briefing, show the link to view it-->
+              @if ($flight->simbrief && $flight->simbrief->user_id === $user->id)
+                <a href="{{ route('frontend.simbrief.briefing', $flight->simbrief->id) }}"
+                   class="btn btn-sm btn-outline-primary">
+                  View Simbrief Flight Plan
+                </a>
+              @else
+                <!-- Show button if the bids-only is disable, or if bids-only is enabled, they've saved it -->
+                @if ($simbrief_bids === false || ($simbrief_bids === true && isset($saved[$flight->id])))
+                  @php
+                    $aircraft_id = isset($saved[$flight->id]) ? App\Models\Bid::find($saved[$flight->id])->aircraft_id : null;
+                  @endphp
+                  <a href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}@if($aircraft_id)&aircraft_id={{ $aircraft_id }} @endif"
+                     class="btn btn-sm btn-outline-primary">
+                    Create Simbrief Flight Plan
+                  </a>
+                @endif
+              @endif
+             @endif
+            <a href="{{ route('frontend.pireps.create') }}?flight_id={{ $flight->id }}"
+               class="btn btn-sm btn-outline-info">
+              {{ __('pireps.newpirep') }}
+            </a>
           @endif
-          <a href="{{ route('frontend.pireps.create') }}?flight_id={{ $flight->id }}"
-             class="btn btn-sm btn-outline-info">
-            {{ __('pireps.newpirep') }}
-          </a>
         </div>
       </div>
     </div>

--- a/resources/views/layouts/seven/flights/table.blade.php
+++ b/resources/views/layouts/seven/flights/table.blade.php
@@ -102,38 +102,38 @@
             <a class="btn btn-sm btn-primary" href="{{ route('frontend.flights.show', [$flight->id]) }}">
                 {{ __('flights.viewflight') }}
             </a>
-            @if ($acars_plugin)
+            @if (!setting('pilots.only_flights_from_current') || $flight->dpt_airport_id === $user->current_airport->icao)
+              @if ($acars_plugin)
                 @if (isset($saved[$flight->id]))
-                    <a href="vmsacars:bid/{{ $saved[$flight->id] }}" class="btn btn-sm btn-primary">Load in
-                        vmsACARS</a>
+                  <a href="vmsacars:bid/{{ $saved[$flight->id] }}" class="btn btn-sm btn-primary">Load in
+                    vmsACARS</a>
                 @else
-                    <a href="vmsacars:flight/{{ $flight->id }}" class="btn btn-sm btn-primary">Load in vmsACARS</a>
+                  <a href="vmsacars:flight/{{ $flight->id }}" class="btn btn-sm btn-primary">Load in vmsACARS</a>
                 @endif
-            @endif
-            @if ($simbrief !== false)
+               @endif
+              @if ($simbrief !== false)
                 @if ($flight->simbrief && $flight->simbrief->user_id === $user->id)
-                    <a href="{{ route('frontend.simbrief.briefing', $flight->simbrief->id) }}"
-                        class="btn btn-sm btn-primary">
-                        {{ __('flights.viewsimbrief') }}
-                    </a>
+                  <a href="{{ route('frontend.simbrief.briefing', $flight->simbrief->id) }}"
+                     class="btn btn-sm btn-primary">
+                    {{ __('flights.viewsimbrief') }}
+                  </a>
                 @else
-                    @if ($simbrief_bids === false || ($simbrief_bids === true && isset($saved[$flight->id])))
-                        @php
-                            $aircraft_id = isset($saved[$flight->id])
-                                ? App\Models\Bid::find($saved[$flight->id])->aircraft_id
-                                : null;
-                        @endphp
-                        <a href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}@if ($aircraft_id) &aircraft_id={{ $aircraft_id }} @endif"
-                            class="btn btn-sm btn-primary">
-                            {{ __('flights.createsimbrief') }}
-                        </a>
-                    @endif
+                  @if ($simbrief_bids === false || ($simbrief_bids === true && isset($saved[$flight->id])))
+                    @php
+                        $aircraft_id = isset($saved[$flight->id])
+                            ? App\Models\Bid::find($saved[$flight->id])->aircraft_id
+                            : null;
+                      @endphp
+                    <a href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}@if ($aircraft_id) &aircraft_id={{ $aircraft_id }} @endif"
+                       class="btn btn-sm btn-primary">
+                      {{ __('flights.createsimbrief') }}
+                    </a>
+                  @endif
                 @endif
-            @endif
-            <a href="{{ route('frontend.pireps.create') }}?flight_id={{ $flight->id }}" class="btn btn-sm btn-info">
-                {{ __('pireps.newpirep') }}
-            </a>
-            @if (!setting('pilots.only_flights_from_current') || $flight->dpt_airport_id == $user->current_airport->icao)
+               @endif
+                <a href="{{ route('frontend.pireps.create') }}?flight_id={{ $flight->id }}" class="btn btn-sm btn-info">
+                  {{ __('pireps.newpirep') }}
+                </a>
                 <button
                     class="btn btn-sm save_flight
                            {{ isset($saved[$flight->id]) ? 'btn-danger' : 'btn-success' }}"


### PR DESCRIPTION
Closes #1977 
Closes #1510 

This pull request splits the old 'only allow/show flights from current airport' setting into two separate settings. Now you can show all flights while only allowing them to be flown if the pilot is at the current airport.

Admin settings:

<img width="333" height="148" alt="image" src="https://github.com/user-attachments/assets/453041d5-2f6b-4d39-9560-e6b298f723a1" />

If you select 'only allow flights from current' but not 'only show flights from current,' you'll see all flights,but you won't be able to bid, generate a SimBrief OFP, or file a manual PIREP on any of them.

<img width="1893" height="939" alt="image" src="https://github.com/user-attachments/assets/aed24f0d-f6ef-47f3-b9b9-8157edd51812" />

Does this match what you had in mind @avs-code @FatihKoz ?