### PR TITLE
feat(pireps): pirep view extension points

### DIFF
--- a/app/Filament/Resources/Pireps/Pages/ViewPirep.php
+++ b/app/Filament/Resources/Pireps/Pages/ViewPirep.php
@@ -159,6 +159,15 @@ class ViewPirep extends ViewRecord
      *
      * The addon view is passed ONLY the record, never the page's scope.
      *
+     * Two independent failure modes, both contained: a throwing `visible`,
+     * `label` or `badge` closure drops the whole tab (with no label there is
+     * nothing to put on a button), while a throwing view keeps the tab and
+     * shows fallback content in its panel. Both report the exception.
+     *
+     * `domId` is prefixed and hash-suffixed so it can neither collide with the
+     * built-in `tab-*`/`t-*` ids nor with another addon whose id slugifies the
+     * same way (`acme.a.b` and `acme.a-b` both slugify to `acme-a-b`).
+     *
      * @return array<int, array{id: string, domId: string, label: string, badge: string|int|null, html: string}>
      */
     private function extensionTabs(): array
@@ -169,7 +178,16 @@ class ViewPirep extends ViewRecord
         $tabs = [];
 
         foreach (app(PirepViewTabRegistry::class)->ordered() as $tab) {
-            if (!$resolve($tab['visible'] ?? true)) {
+            try {
+                if (!$resolve($tab['visible'] ?? true)) {
+                    continue;
+                }
+
+                $label = (string) $resolve($tab['label']);
+                $badge = $resolve($tab['badge'] ?? null);
+            } catch (Throwable $throwable) {
+                report($throwable);
+
                 continue;
             }
 
@@ -183,12 +201,10 @@ class ViewPirep extends ViewRecord
             }
 
             $tabs[] = [
-                'id' => $tab['id'],
-                // Ids are namespaced ('vendor.name'); a dot is legal in an HTML
-                // id but not in a CSS/querySelector one, so derive a safe one.
-                'domId' => preg_replace('/[^A-Za-z0-9_-]+/', '-', $tab['id']),
-                'label' => (string) $resolve($tab['label'] ?? ''),
-                'badge' => $resolve($tab['badge'] ?? null),
+                'id'    => $tab['id'],
+                'domId' => 'ext-'.preg_replace('/[^A-Za-z0-9_-]+/', '-', $tab['id']).'-'.substr(md5($tab['id']), 0, 6),
+                'label' => $label,
+                'badge' => $badge,
                 'html'  => $html,
             ];
         }

--- a/app/Filament/Resources/Pireps/Pages/ViewPirep.php
+++ b/app/Filament/Resources/Pireps/Pages/ViewPirep.php
@@ -10,6 +10,8 @@ use App\Models\PirepEvent;
 use App\Services\Finance\PirepFinanceService;
 use App\Services\GeoService;
 use App\Services\Pirep\PerformanceChartService;
+use App\Support\PirepView\PirepViewTabRegistry;
+use Closure;
 use Filafly\Icons\Phosphor\Enums\Phosphor;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
@@ -128,6 +130,70 @@ class ViewPirep extends ViewRecord
     {
         // No default infolist — the custom blade renders the detail layout.
         return $schema->components([]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
+    protected function getViewData(): array
+    {
+        return [
+            ...parent::getViewData(),
+            'extensionTabs' => $this->extensionTabs(),
+        ];
+    }
+
+    /**
+     * Addon-registered subtabs for this record (PirepViewTabRegistry): drop the
+     * ones whose `visible` closure says no, resolve label/badge, render each
+     * panel to HTML.
+     *
+     * Panels are rendered HERE — from getViewData(), before the page view
+     * starts rendering — and never from inside the blade. Laravel's
+     * View::render() calls Factory::flushState() when a view throws, which
+     * wipes the GLOBAL component/section stacks; a throwing addon view rendered
+     * inside the page would take the surrounding <x-filament-panels::page>
+     * component down with it (unwinding the output buffers is not enough).
+     * Rendering to a string first keeps a failure inside its own panel.
+     *
+     * The addon view is passed ONLY the record, never the page's scope.
+     *
+     * @return array<int, array{id: string, domId: string, label: string, badge: string|int|null, html: string}>
+     */
+    private function extensionTabs(): array
+    {
+        $record = $this->record;
+        $resolve = static fn (mixed $value): mixed => $value instanceof Closure ? $value($record) : $value;
+
+        $tabs = [];
+
+        foreach (app(PirepViewTabRegistry::class)->ordered() as $tab) {
+            if (!$resolve($tab['visible'] ?? true)) {
+                continue;
+            }
+
+            try {
+                $html = view($tab['view'], ['record' => $record])->render();
+            } catch (Throwable $throwable) {
+                report($throwable);
+                $html = '<div class="panel__body panel__body--centred"><p class="text-ink-3 text-sm">'
+                    .e(__('filament.extension_tab_error'))
+                    .'</p></div>';
+            }
+
+            $tabs[] = [
+                'id' => $tab['id'],
+                // Ids are namespaced ('vendor.name'); a dot is legal in an HTML
+                // id but not in a CSS/querySelector one, so derive a safe one.
+                'domId' => preg_replace('/[^A-Za-z0-9_-]+/', '-', $tab['id']),
+                'label' => (string) $resolve($tab['label'] ?? ''),
+                'badge' => $resolve($tab['badge'] ?? null),
+                'html'  => $html,
+            ];
+        }
+
+        return $tabs;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,6 +36,7 @@ use App\Services\RouteForge\Rules\L8EventDatesOutsideWindow;
 use App\Services\RouteForge\Rules\L9BatchOver50;
 use App\Services\SettingService;
 use App\Support\Branding;
+use App\Support\PirepView\PirepViewTabRegistry;
 use App\Support\ThemeViewFinder;
 use App\Support\Units\Time;
 use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
@@ -326,6 +327,11 @@ class AppServiceProvider extends ServiceProvider
         // during boot(). A PHP enum could never allow that, which is why this
         // is a registry.
         $this->app->singleton(AssetTypes::class);
+
+        // Admin PIREP view tabs: addon providers register onto the SAME
+        // instance the detail partial later reads, so it must be a singleton.
+        // Entries hold closures — never cache or serialize this.
+        $this->app->singleton(PirepViewTabRegistry::class);
 
         // RouteForge lint catalog: tag every concrete rule class so adding a
         // rule means appending one entry here, not editing LintRunner. The

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -328,9 +328,6 @@ class AppServiceProvider extends ServiceProvider
         // is a registry.
         $this->app->singleton(AssetTypes::class);
 
-        // Admin PIREP view tabs: addon providers register onto the SAME
-        // instance the detail partial later reads, so it must be a singleton.
-        // Entries hold closures — never cache or serialize this.
         $this->app->singleton(PirepViewTabRegistry::class);
 
         // RouteForge lint catalog: tag every concrete rule class so adding a

--- a/app/Support/PirepView/PirepViewTabRegistry.php
+++ b/app/Support/PirepView/PirepViewTabRegistry.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\PirepView;
+
+use InvalidArgumentException;
+
+/**
+ * Registry of addon-contributed tabs on the ADMIN PIREP view page.
+ *
+ * `App\Support\PirepView\PirepViewTabRegistry` — the class name and namespace
+ * are the addon-facing contract. An addon resolves it from the container in its
+ * ServiceProvider::boot() (guarded with `class_exists` so the addon still
+ * installs against an older core) and calls `register()`. A DISABLED addon's
+ * provider never boots, so its tab is simply never registered — disable-safety
+ * is a property of the mechanism, not a runtime `enabled` check. Same idea as
+ * App\Support\Skylight\SlotRegistry, but the admin page is not the SPA, so this
+ * deliberately lives outside the Skylight hub.
+ *
+ * Entries carry CLOSURES (label/badge/visible are evaluated per record at
+ * render time). The registry is therefore an in-memory, boot-time singleton and
+ * must never be cached or serialized.
+ */
+final class PirepViewTabRegistry
+{
+    /**
+     * Registered tabs keyed by id — last registration wins, so a tab can be
+     * deliberately replaced. Replacing keeps the original insertion position,
+     * which is what makes `ordered()` deterministic for equal `order` values.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private array $tabs = [];
+
+    /**
+     * Register (or, on a duplicate id, replace) a tab.
+     *
+     * Recognised keys:
+     *   id      string   required, namespaced ('vendor.name'). Doubles as the
+     *                    Alpine `activeTab` value and the source of the panel's
+     *                    DOM id.
+     *   label   string|Closure(Pirep): string           required, escaped as text.
+     *   badge   string|Closure(Pirep): string|int|null  optional, escaped as text.
+     *   visible Closure(Pirep): bool                    optional, default true.
+     *                    False hides both the button and the panel for that record.
+     *   order   int      optional, default 100 — after the built-in tabs. Ties
+     *                    break by registration order.
+     *   view    string   required. Rendered with ONLY `['record' => $pirep]`.
+     *
+     * @param array<string, mixed> $tab
+     */
+    public function register(array $tab): self
+    {
+        if (empty($tab['id']) || !is_string($tab['id'])) {
+            throw new InvalidArgumentException('A PIREP view tab requires a string "id".');
+        }
+
+        if (empty($tab['view']) || !is_string($tab['view'])) {
+            throw new InvalidArgumentException('A PIREP view tab requires a string "view".');
+        }
+
+        $tab['order'] ??= 100;
+
+        $this->tabs[$tab['id']] = $tab;
+
+        return $this;
+    }
+
+    /**
+     * Every registered tab, ascending by `order`. `usort` is stable as of PHP
+     * 8.0, so equal orders keep registration order.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function ordered(): array
+    {
+        $tabs = array_values($this->tabs);
+        usort($tabs, static fn (array $a, array $b): int => $a['order'] <=> $b['order']);
+
+        return $tabs;
+    }
+}

--- a/app/Support/PirepView/PirepViewTabRegistry.php
+++ b/app/Support/PirepView/PirepViewTabRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support\PirepView;
 
+use Closure;
 use InvalidArgumentException;
 
 /**
@@ -40,9 +41,9 @@ final class PirepViewTabRegistry
      *   id      string   required, namespaced ('vendor.name'). Doubles as the
      *                    Alpine `activeTab` value and the source of the panel's
      *                    DOM id.
-     *   label   string|Closure(Pirep): string           required, escaped as text.
-     *   badge   string|Closure(Pirep): string|int|null  optional, escaped as text.
-     *   visible Closure(Pirep): bool                    optional, default true.
+     *   label   string|Closure(Pirep): string             required, escaped as text.
+     *   badge   string|int|Closure(Pirep): string|int|null  optional, escaped as text.
+     *   visible Closure(Pirep): bool                      optional, default true.
      *                    False hides both the button and the panel for that record.
      *   order   int      optional, default 100 — after the built-in tabs. Ties
      *                    break by registration order.
@@ -58,6 +59,22 @@ final class PirepViewTabRegistry
 
         if (empty($tab['view']) || !is_string($tab['view'])) {
             throw new InvalidArgumentException('A PIREP view tab requires a string "view".');
+        }
+
+        if (!isset($tab['label']) || !is_string($tab['label']) && !$tab['label'] instanceof Closure) {
+            throw new InvalidArgumentException('A PIREP view tab requires a string or Closure "label".');
+        }
+
+        if (isset($tab['badge']) && !(is_string($tab['badge']) || is_int($tab['badge']) || $tab['badge'] instanceof Closure)) {
+            throw new InvalidArgumentException('A PIREP view tab "badge" must be a string, an int or a Closure.');
+        }
+
+        if (isset($tab['visible']) && !$tab['visible'] instanceof Closure) {
+            throw new InvalidArgumentException('A PIREP view tab "visible" must be a Closure.');
+        }
+
+        if (isset($tab['order']) && !is_int($tab['order'])) {
+            throw new InvalidArgumentException('A PIREP view tab "order" must be an int.');
         }
 
         $tab['order'] ??= 100;

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -113,7 +113,9 @@ public function boot(): void
 The view gets the record and nothing else — not the page's `$mapFeatures`, `$logEntries` or
 `$this`. It is rendered to a string by `ViewPirep::getViewData()` before the page renders, inside
 a `Throwable` catch: if it throws, the exception is reported and that one panel shows fallback
-text while the rest of the page renders normally. (It cannot be rendered from inside the page
+text while the rest of the page renders normally. A `visible`, `label` or `badge` closure that
+throws is also reported, but drops the whole tab — with no label there is nothing to put on a
+button. Either way the page still renders. (The view cannot be rendered from inside the page
 view: Laravel's `View::render()` calls `Factory::flushState()` when a view throws, which wipes the
 global component stack and would take the whole page down.)
 

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -69,3 +69,73 @@
 │      └── Octane::reload()  ← activates new providers on next worker boot         │
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
+
+## PIREP view extension points
+
+Two hooks let an addon add content to the PIREP pages without core changing again.
+
+### Admin: a tab on the PIREP view page
+
+`App\Support\PirepView\PirepViewTabRegistry` is a container singleton. Register from your
+`ServiceProvider::boot()`; a disabled addon's provider never boots, so its tab simply never
+appears. Guard with `class_exists` so the addon still installs against an older core.
+
+```php
+use App\Models\Pirep;
+use App\Support\PirepView\PirepViewTabRegistry;
+
+public function boot(): void
+{
+    if (!class_exists(PirepViewTabRegistry::class)) {
+        return;
+    }
+
+    app(PirepViewTabRegistry::class)->register([
+        'id'      => 'vmsacars.debrief',                       // required, namespaced
+        'label'   => fn (Pirep $pirep): string => __('vmsacars::debrief.tab_label'),
+        'badge'   => fn (Pirep $pirep): ?int => PirepDebrief::where('pirep_id', $pirep->id)->count() ?: null,
+        'visible' => fn (Pirep $pirep): bool => PirepDebrief::where('pirep_id', $pirep->id)->exists(),
+        'order'   => 100,
+        'view'    => 'vmsacars::pirep-debrief-tab',
+    ]);
+}
+```
+
+| Key       | Type                                                  | Notes                                                                                                                           |
+| --------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`      | `string`                                              | Required, namespaced `vendor.name`. Doubles as the Alpine tab value; a duplicate id **replaces** the earlier entry (last-wins). |
+| `label`   | `string` or `Closure(Pirep): string`                  | Rendered as escaped text.                                                                                                       |
+| `badge`   | `string`/`int` or `Closure(Pirep): string\|int\|null` | Optional. Escaped; hidden when blank.                                                                                           |
+| `visible` | `Closure(Pirep): bool`                                | Optional, default true. False hides both the button and the panel for that record.                                              |
+| `order`   | `int`                                                 | Optional, default 100 — i.e. after the built-in tabs. Ties keep registration order.                                             |
+| `view`    | `string`                                              | Required Blade view, rendered with **only** `['record' => $pirep]`.                                                             |
+
+The view gets the record and nothing else — not the page's `$mapFeatures`, `$logEntries` or
+`$this`. It is rendered to a string by `ViewPirep::getViewData()` before the page renders, inside
+a `Throwable` catch: if it throws, the exception is reported and that one panel shows fallback
+text while the rest of the page renders normally. (It cannot be rendered from inside the page
+view: Laravel's `View::render()` calls `Factory::flushState()` when a view throws, which wipes the
+global component stack and would take the whole page down.)
+
+Panels render eagerly with the page, like the built-in tabs. If your content is expensive, defer
+inside your own view — render a mount point and load it on demand.
+
+Closures are not serializable; the registry is an in-memory, boot-time singleton and is never
+cached.
+
+### Frontend: the `pireps.detail.main` slot
+
+The skylight SPA's PIREP detail layout exposes a Skylight slot with the pirep as context:
+
+```php
+Skylight::slots()->register([
+    'slot'      => 'pireps.detail.main',
+    'component' => 'AcarsDebriefPanel',
+    'module'    => '/ext/vmsacars/widgets/debrief.js',
+    'props'     => ['pirep' => '@pirep'],   // @-ref resolved from the slot context
+]);
+```
+
+It sits full-width below the two-column detail grid, and renders nothing at all when no addon
+targets it. See `modules/phpvms-sample-vue-slot/` for a complete working addon (registration,
+the Vue component, and the ESM build step).

--- a/modules/phpvms-sample-vue-slot/README.md
+++ b/modules/phpvms-sample-vue-slot/README.md
@@ -76,8 +76,8 @@ props, so a `@bid` ref works even though `bid` is not a page-level prop.
 
 Relevant source (read-only):
 - `app/Support/Skylight/SlotRegistry.php` — the `register()` contract.
-- `resources/js/apps/fe-vue/src/components/pv/PvSlot.vue` — resolves `@`-refs against `{ ...pageProps, ...context }`.
-- `resources/js/apps/fe-vue/src/components/pv/PvApp.vue` — for each server slot entry with a `module`, registers `resolver[component] = defineAsyncComponent(() => import(module))`.
+- `resources/js/apps/fe-vue/src/shared/components/PvSlot.vue` — resolves `@`-refs against `{ ...pageProps, ...context }`.
+- `resources/js/apps/fe-vue/src/app/PvApp.vue` — for each server slot entry with a `module`, registers `resolver[component] = defineAsyncComponent(() => import(module))`.
 
 Because of PvApp's resolver step, a slot entry needs **both** a unique
 `component` name (the resolver key) **and** a `module` URL (what to import).

--- a/modules/phpvms-sample-vue-slot/README.md
+++ b/modules/phpvms-sample-vue-slot/README.md
@@ -77,7 +77,8 @@ props, so a `@bid` ref works even though `bid` is not a page-level prop.
 Relevant source (read-only):
 - `app/Support/Skylight/SlotRegistry.php` — the `register()` contract.
 - `resources/js/apps/fe-vue/src/shared/components/PvSlot.vue` — resolves `@`-refs against `{ ...pageProps, ...context }`.
-- `resources/js/apps/fe-vue/src/app/PvApp.vue` — for each server slot entry with a `module`, registers `resolver[component] = defineAsyncComponent(() => import(module))`.
+- `resources/js/apps/fe-vue/src/app/PvApp.vue` — calls `provideExtensionContext()` at the app root.
+- `resources/js/apps/fe-vue/src/app/extensions/provideExtensionContext.ts` — iterates the server slot entries and, for each one with a `module`, registers `resolver[component] = defineAsyncComponent(() => import(module))`.
 
 Because of PvApp's resolver step, a slot entry needs **both** a unique
 `component` name (the resolver key) **and** a `module` URL (what to import).

--- a/resources/js/apps/fe-vue/src/widgets/pireps/PirepDetailView.vue
+++ b/resources/js/apps/fe-vue/src/widgets/pireps/PirepDetailView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Link } from "@inertiajs/vue3";
+import PvSlot from "@/shared/components/PvSlot.vue";
 import PirepContent from "./PirepContent.vue";
 import PirepDetails from "./PirepDetails.vue";
 import PirepSummary from "./PirepSummary.vue";
@@ -15,6 +16,7 @@ defineProps<{ pirep: App.Http.Data.PirepData }>();
       <PirepContent :pirep />
       <PirepDetails :pirep />
     </div>
+    <PvSlot name="pireps.detail.main" :context="{ pirep }" />
   </section>
 </template>
 

--- a/resources/lang/en/filament.php
+++ b/resources/lang/en/filament.php
@@ -111,6 +111,7 @@ return [
     'planned_details'                  => 'Planned Details',
     'original_flight'                  => 'Original Flight',
     'original_flight_empty'            => 'No archived flight data is available for this PIREP.',
+    'extension_tab_error'              => 'This section could not be displayed.',
     'filed_after'                      => 'Filed after',
     'filed_before'                     => 'Filed before',
     'rank_information'                 => 'Rank Information',

--- a/resources/views/filament/pireps/pages/view-pirep.blade.php
+++ b/resources/views/filament/pireps/pages/view-pirep.blade.php
@@ -8,8 +8,9 @@
 
 <x-filament-panels::page>
     @include('filament.pireps.partials.detail.index', [
-        'record'      => $record,
-        'mapFeatures' => $mapFeatures,
-        'performance' => $performance,
+        'record'        => $record,
+        'mapFeatures'   => $mapFeatures,
+        'performance'   => $performance,
+        'extensionTabs' => $extensionTabs,
     ])
 </x-filament-panels::page>

--- a/resources/views/filament/pireps/partials/detail/index.blade.php
+++ b/resources/views/filament/pireps/partials/detail/index.blade.php
@@ -70,7 +70,6 @@
                 @svg('phosphor-archive-light') {{ __('filament.original_flight') }}
             </button>
 
-            {{-- Addon-registered subtabs, after the built-ins --}}
             @foreach ($extensionTabs as $tab)
                 <button
                     type="button"

--- a/resources/views/filament/pireps/partials/detail/index.blade.php
+++ b/resources/views/filament/pireps/partials/detail/index.blade.php
@@ -12,6 +12,12 @@
     // Computed once here so the "Flight log <em>N</em>" subtab badge and the
     // Flight Log tab body share a single query instead of two.
     $logEntries = $this->logEntries;
+
+    /* Addon-registered subtabs, already resolved and rendered to HTML by
+       ViewPirep::getViewData() — see the docblock there for why the panels
+       cannot be rendered from inside this view.
+       @var array<int, array{id: string, domId: string, label: string, badge: string|int|null, html: string}> $extensionTabs */
+    $extensionTabs = $extensionTabs ?? [];
 @endphp
 
 @include('filament.pireps.partials.detail.header', ['record' => $record])
@@ -63,6 +69,21 @@
             >
                 @svg('phosphor-archive-light') {{ __('filament.original_flight') }}
             </button>
+
+            {{-- Addon-registered subtabs, after the built-ins --}}
+            @foreach ($extensionTabs as $tab)
+                <button
+                    type="button"
+                    class="subtab"
+                    role="tab"
+                    :aria-selected="activeTab === @js($tab['id'])"
+                    aria-controls="tab-{{ $tab['domId'] }}"
+                    id="t-{{ $tab['domId'] }}"
+                    @click="activeTab = @js($tab['id'])"
+                >
+                    {{ $tab['label'] }}@if (filled($tab['badge'])) <em>{{ $tab['badge'] }}</em>@endif
+                </button>
+            @endforeach
         </div>
 
         {{-- Flight tab: route bar + map + vertical profile chart + touchdown + notes --}}
@@ -91,6 +112,14 @@
         <div id="tab-arc" role="tabpanel" aria-labelledby="t-arc" x-show="activeTab === 'archive'" x-cloak>
             @include('filament.pireps.partials.detail.archive', ['record' => $record])
         </div>
+
+        {{-- Addon-registered panels, pre-rendered (and error-contained) by the
+             page class. --}}
+        @foreach ($extensionTabs as $tab)
+            <div id="tab-{{ $tab['domId'] }}" role="tabpanel" aria-labelledby="t-{{ $tab['domId'] }}" x-show="activeTab === @js($tab['id'])" x-cloak>
+                {!! $tab['html'] !!}
+            </div>
+        @endforeach
     </section>
 
     @include('filament.pireps.partials.detail.sidebar', ['record' => $record])

--- a/tests/Feature/Filament/PirepViewPageTest.php
+++ b/tests/Feature/Filament/PirepViewPageTest.php
@@ -4,7 +4,24 @@ use App\Enums\PirepState;
 use App\Filament\Resources\Pireps\PirepResource;
 use App\Models\Pirep;
 use App\Services\PirepService;
+use App\Support\PirepView\PirepViewTabRegistry;
 use Database\Seeders\RolesPermissionsSeeder;
+use Illuminate\Support\Facades\View;
+
+/**
+ * Registers the addon tab fixture views under the `pireptabs::` namespace and
+ * hands back an EMPTY tab registry — whatever addons this checkout happens to
+ * have enabled must not add tabs to the assertions below.
+ */
+function pirepTabRegistry(): PirepViewTabRegistry
+{
+    View::addNamespace('pireptabs', __DIR__.'/fixtures/pirep-tabs');
+
+    $registry = new PirepViewTabRegistry();
+    app()->instance(PirepViewTabRegistry::class, $registry);
+
+    return $registry;
+}
 
 test('admin view-pirep page renders detail layout', function (): void {
     $this->seed(RolesPermissionsSeeder::class);
@@ -72,4 +89,124 @@ test('view-pirep page renders without error for a pirep with no archive row', fu
         ->get(PirepResource::getUrl('view', ['record' => $pirep]))
         ->assertSuccessful()
         ->assertSee(__('filament.original_flight_empty'));
+});
+
+test('view-pirep page renders an addon-registered tab with a record-derived label and badge', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    pirepTabRegistry()->register([
+        'id'    => 'acme.debrief',
+        'label' => fn (Pirep $p): string => 'ACME '.$p->ident,
+        'badge' => fn (Pirep $p): string => 'BADGE-'.$p->ident,
+        'view'  => 'pireptabs::ok',
+    ]);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->assertSee('ACME '.$pirep->ident)
+        ->assertSee('BADGE-'.$pirep->ident)
+        // Alpine wiring + the dot-free DOM id derived from the namespaced id.
+        ->assertSee('id="tab-acme-debrief"', false)
+        ->assertSee('TAB-PANEL-OK '.$pirep->ident)
+        // The addon view sees only the record, not the page's variables.
+        ->assertSee('SCOPE-CLEAN')
+        ->assertDontSee('SCOPE-LEAKED');
+});
+
+test('view-pirep page hides an addon tab whose visible closure returns false', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    pirepTabRegistry()->register([
+        'id'      => 'acme.hidden',
+        'label'   => 'ZZ-HIDDEN-TAB',
+        'visible' => fn (Pirep $p): bool => false,
+        'view'    => 'pireptabs::ok',
+    ]);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->assertDontSee('ZZ-HIDDEN-TAB')
+        ->assertDontSee('TAB-PANEL-OK')
+        ->assertDontSee('tab-acme-hidden', false);
+});
+
+test('view-pirep page orders addon tabs by their order value, after the built-ins', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    // Registered high-order first, so passing requires the sort, not luck.
+    pirepTabRegistry()
+        ->register(['id' => 'acme.late', 'label' => 'ZZ-LATE-TAB', 'order' => 200, 'view' => 'pireptabs::ok'])
+        ->register(['id' => 'acme.early', 'label' => 'ZZ-EARLY-TAB', 'order' => 50, 'view' => 'pireptabs::ok']);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->assertSeeInOrder([__('filament.original_flight'), 'ZZ-EARLY-TAB', 'ZZ-LATE-TAB']);
+});
+
+test('view-pirep page lets a duplicate tab id replace the earlier registration', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    pirepTabRegistry()
+        ->register(['id' => 'acme.debrief', 'label' => 'ZZ-ORIGINAL-TAB', 'view' => 'pireptabs::ok'])
+        ->register(['id' => 'acme.debrief', 'label' => 'ZZ-REPLACEMENT-TAB', 'view' => 'pireptabs::ok']);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->assertSee('ZZ-REPLACEMENT-TAB')
+        ->assertDontSee('ZZ-ORIGINAL-TAB');
+});
+
+test('view-pirep page survives an addon tab view that throws', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    pirepTabRegistry()
+        ->register(['id' => 'acme.boom', 'label' => 'ZZ-BROKEN-TAB', 'view' => 'pireptabs::boom'])
+        ->register(['id' => 'acme.ok', 'label' => 'ZZ-HEALTHY-TAB', 'view' => 'pireptabs::ok']);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        // Built-in tabs intact, the healthy sibling tab intact.
+        ->assertSee(__('filament.original_flight'))
+        ->assertSee('ZZ-HEALTHY-TAB')
+        ->assertSee('TAB-PANEL-OK '.$pirep->ident)
+        // Failing panel: fallback content, and no half-rendered output leaked.
+        ->assertSee('ZZ-BROKEN-TAB')
+        ->assertSee(__('filament.extension_tab_error'))
+        ->assertDontSee('TAB-PANEL-PARTIAL-OUTPUT');
+});
+
+test('view-pirep page renders the built-in tabs untouched when no addon registered a tab', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    expect(pirepTabRegistry()->ordered())->toBe([]);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->assertSee(__('pireps.flight_log'))
+        ->assertSee(__('filament.original_flight'))
+        ->assertDontSee(__('filament.extension_tab_error'));
 });

--- a/tests/Feature/Filament/PirepViewPageTest.php
+++ b/tests/Feature/Filament/PirepViewPageTest.php
@@ -109,8 +109,8 @@ test('view-pirep page renders an addon-registered tab with a record-derived labe
         ->assertSuccessful()
         ->assertSee('ACME '.$pirep->ident)
         ->assertSee('BADGE-'.$pirep->ident)
-        // Alpine wiring + the dot-free DOM id derived from the namespaced id.
-        ->assertSee('id="tab-acme-debrief"', false)
+        // Prefixed, hash-suffixed DOM id derived from the namespaced id.
+        ->assertSee('id="tab-ext-acme-debrief-'.substr(md5('acme.debrief'), 0, 6).'"', false)
         ->assertSee('TAB-PANEL-OK '.$pirep->ident)
         // The addon view sees only the record, not the page's variables.
         ->assertSee('SCOPE-CLEAN')
@@ -135,7 +135,7 @@ test('view-pirep page hides an addon tab whose visible closure returns false', f
         ->assertSuccessful()
         ->assertDontSee('ZZ-HIDDEN-TAB')
         ->assertDontSee('TAB-PANEL-OK')
-        ->assertDontSee('tab-acme-hidden', false);
+        ->assertDontSee('acme-hidden', false);
 });
 
 test('view-pirep page orders addon tabs by their order value, after the built-ins', function (): void {
@@ -209,4 +209,79 @@ test('view-pirep page renders the built-in tabs untouched when no addon register
         ->assertSee(__('pireps.flight_log'))
         ->assertSee(__('filament.original_flight'))
         ->assertDontSee(__('filament.extension_tab_error'));
+});
+
+test('view-pirep page drops an addon tab whose metadata closure throws', function (string $key): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    $boom = function (Pirep $p): never {
+        throw new RuntimeException('metadata closure exploded');
+    };
+
+    pirepTabRegistry()
+        ->register([
+            'id'    => 'acme.boom',
+            'label' => 'ZZ-BROKEN-TAB',
+            'view'  => 'pireptabs::ok',
+            $key    => $boom,
+        ])
+        ->register(['id' => 'acme.ok', 'label' => 'ZZ-HEALTHY-TAB', 'view' => 'pireptabs::ok']);
+
+    $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        // No label to put on a button, so the whole tab goes — not even a
+        // fallback panel. Its healthy sibling and the built-ins are untouched.
+        ->assertDontSee('ZZ-BROKEN-TAB')
+        ->assertDontSee('acme-boom', false)
+        ->assertDontSee(__('filament.extension_tab_error'))
+        ->assertSee('ZZ-HEALTHY-TAB')
+        ->assertSee(__('filament.original_flight'));
+})->with(['visible', 'label', 'badge']);
+
+test('view-pirep page gives colliding tab slugs distinct DOM ids', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $pirep = Pirep::factory()->create(['state' => PirepState::PENDING]);
+
+    // All three slugify to `acme-a-b`/`acme-a_b`; only the hash separates the
+    // first and third.
+    $ids = ['acme.a-b', 'acme.a_b', 'acme.a.b'];
+
+    $registry = pirepTabRegistry();
+    foreach ($ids as $id) {
+        $registry->register(['id' => $id, 'label' => 'ZZ-TAB-'.$id, 'view' => 'pireptabs::ok']);
+    }
+
+    $html = $this->actingAs($admin)
+        ->get(PirepResource::getUrl('view', ['record' => $pirep]))
+        ->assertSuccessful()
+        ->getContent();
+
+    $domIds = [];
+    foreach ($ids as $id) {
+        preg_match('/id="(tab-ext-[^"]+'.substr(md5($id), 0, 6).')"/', $html, $m);
+        $domIds[] = $m[1] ?? null;
+    }
+
+    expect($domIds)->not->toContain(null)
+        ->and(array_unique($domIds))->toHaveCount(3);
+});
+
+test('the tab registry rejects a definition with no label', function (): void {
+    expect(fn (): PirepViewTabRegistry => new PirepViewTabRegistry()->register(['id' => 'acme.x', 'view' => 'pireptabs::ok']))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('the tab registry rejects a non-int order', function (): void {
+    expect(fn (): PirepViewTabRegistry => new PirepViewTabRegistry()->register([
+        'id'    => 'acme.x',
+        'label' => 'X',
+        'view'  => 'pireptabs::ok',
+        'order' => '50',
+    ]))->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Feature/Filament/fixtures/pirep-tabs/boom.blade.php
+++ b/tests/Feature/Filament/fixtures/pirep-tabs/boom.blade.php
@@ -1,0 +1,4 @@
+TAB-PANEL-PARTIAL-OUTPUT
+@php
+    throw new RuntimeException('pirep tab fixture exploded');
+@endphp

--- a/tests/Feature/Filament/fixtures/pirep-tabs/ok.blade.php
+++ b/tests/Feature/Filament/fixtures/pirep-tabs/ok.blade.php
@@ -1,0 +1,5 @@
+<div class="pirep-tab-fixture">
+    TAB-PANEL-OK {{ $record->ident }}
+    {{-- The registered view must receive ONLY the record, never the page scope. --}}
+    {{ isset($mapFeatures) || isset($logEntries) ? 'SCOPE-LEAKED' : 'SCOPE-CLEAN' }}
+</div>

--- a/tests/Feature/Filament/fixtures/pirep-tabs/ok.blade.php
+++ b/tests/Feature/Filament/fixtures/pirep-tabs/ok.blade.php
@@ -1,5 +1,4 @@
 <div class="pirep-tab-fixture">
     TAB-PANEL-OK {{ $record->ident }}
-    {{-- The registered view must receive ONLY the record, never the page scope. --}}
     {{ isset($mapFeatures) || isset($logEntries) ? 'SCOPE-LEAKED' : 'SCOPE-CLEAN' }}
 </div>


### PR DESCRIPTION
Addons can now add tabs to the admin PIREP view and inject content into the frontend PIREP detail page, without core edits per addon.

- `PirepViewTabRegistry` (container singleton) takes `id`, `label`, `badge`, `visible`, `order`, `view`. Label, badge, and visible accept per-record closures because registration happens at boot but visibility is a per-PIREP decision - the first consumer hides its tab when a PIREP has no data for it.
- Registered panels pre-render to strings in `ViewPirep::getViewData()` inside a Throwable catch, not inside the Blade partial. A throwing view makes `View::render()` flush the global component stack, which 500s the whole page even when caught - the test for a throwing tab is the one that found this.
- Addon views receive only the record. `@include` was rejected because it leaks the entire page scope into the addon's view.
- Duplicate ids are last-wins so an addon can deliberately replace a tab; `order` defaults to 100, after the built-ins.
- Frontend: one `<PvSlot name="pireps.detail.main">` in `PirepDetailView.vue`, full-width below the detail grid. Name follows the existing `<plural>.<area>.<role>` slot convention. Placement is a default - move it if it reads wrong in the browser.
- Docs in `docs/addons.md` with a registration example; also fixed two stale paths in the sample module's README.
- The 4 pre-existing fe-vue vitest failures (`flight-manifest`, `shared-vue`) are in files this diff doesn't touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable tabs to admin PIREP detail views, including labels, badges, visibility rules, and ordering.
  - Added a frontend extension slot to PIREP detail pages for addon content.
  - Added graceful fallback messaging when an extension tab cannot be displayed.

- **Documentation**
  - Documented PIREP view tabs and frontend extension slots.
  - Updated sample component references.

- **Tests**
  - Added coverage for tab rendering, ordering, visibility, replacement, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->