### PR TITLE
fix(addons): Autoload classes before migrations

### DIFF
--- a/modules/phpvms-addon-manager/app/Jobs/InstallAddonJob.php
+++ b/modules/phpvms-addon-manager/app/Jobs/InstallAddonJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\AddonManager\Jobs;
 
+use App\Addons\AddonAutoLoader;
 use App\Addons\AddonRegistry;
 use App\Addons\Sources\UrlSource;
 use App\Addons\Support\ManifestParser;
@@ -237,6 +238,12 @@ class InstallAddonJob implements ShouldQueue
 
         if (!is_dir($path)) {
             return;
+        }
+
+        $manifest = app(ManifestParser::class)->parse($addon->getPath());
+
+        if ($manifest !== null) {
+            app(AddonAutoLoader::class)->registerClasses($manifest);
         }
 
         $exit = Artisan::call('migrate', [

--- a/tests/Feature/AddonManager/InstallAddonJobTest.php
+++ b/tests/Feature/AddonManager/InstallAddonJobTest.php
@@ -130,6 +130,53 @@ it('installs a verified addon (happy path)', function (): void {
     expect(DB::table('notifications')->where('notifiable_id', $this->user->id)->count())->toBe(1);
 });
 
+it('autoloads addon classes before running migrations', function (bool $updating): void {
+    if ($updating) {
+        $v1 = buildAddonZip($this->work.'/demo-v1.zip', 'acme/demo', '1.0.0');
+        fakeRegistry('acme/demo', '1.0.0', $v1, $this->secret);
+        runInstall('acme/demo', '1.0.0', false, $this->user->id);
+    }
+
+    $namespace = 'Modules\\MigrationDemo'.str_replace('.', '', uniqid('', true));
+    $zipPath = buildAddonZip($this->work.'/demo.zip', 'acme/demo', '2.0.0');
+    $zip = new ZipArchive();
+    $zip->open($zipPath);
+    $zip->addFromString('composer.json', json_encode([
+        'autoload' => ['psr-4' => [$namespace.'\\' => 'app/']],
+    ]));
+    $zip->addFromString('app/Support/Permissions.php', str_replace('ADDON_NAMESPACE', $namespace, <<<'PHP'
+<?php
+namespace ADDON_NAMESPACE\Support;
+final class Permissions
+{
+    public const ADMIN = 'demo:admin';
+}
+PHP));
+    $zip->addFromString('database/migrations/2026_01_01_000000_create_demo_permissions.php', str_replace('ADDON_NAMESPACE', $namespace, <<<'PHP'
+<?php
+use ADDON_NAMESPACE\Support\Permissions;
+use App\Models\Permission;
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration {
+    public function up(): void
+    {
+        Permission::firstOrCreate(['name' => Permissions::ADMIN, 'guard_name' => 'web']);
+    }
+};
+PHP));
+    $zip->close();
+    fakeRegistry('acme/demo', '2.0.0', $zipPath, $this->secret);
+
+    expect(class_exists($namespace.'\\Support\\Permissions', false))->toBeFalse();
+
+    runInstall('acme/demo', '2.0.0', true, $this->user->id);
+
+    $progress = InstallProgress::get('acme/demo');
+    expect($progress['status'])->toBe('done', $progress['message']);
+    expect(Addon::where('registry_id', 'acme/demo')->value('version'))->toBe('2.0.0');
+    $this->assertDatabaseHas('permissions', ['name' => 'demo:admin', 'guard_name' => 'web']);
+})->with(['fresh install' => false, 'update' => true]);
+
 it('rejects a bad signature and downloads nothing', function (): void {
     $zip = buildAddonZip($this->work.'/demo.zip', 'acme/demo', '1.0.0');
     $wrongKp = sodium_crypto_sign_keypair();


### PR DESCRIPTION
Register addon classes before running install or update migrations. This fixes fresh ACARS installs failing with `Modules\Acars\Support\Permissions` not found.

1. Use the installed manifest to register autoloading in the current process before migrations run.
2. Add regression coverage for migrations that use addon classes during fresh installs and updates. All 14 installer tests pass (54 assertions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Add-on classes are now available before database migrations run, improving installation and update reliability for add-ons that define custom classes.
  * Activity calendar deep links now provide consistent results regardless of the time of day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->